### PR TITLE
Patch de resolução para prevenir callbacks duplicados

### DIFF
--- a/src/main/java/me/saiintbrisson/minecraft/DelegatedViewProvider.java
+++ b/src/main/java/me/saiintbrisson/minecraft/DelegatedViewProvider.java
@@ -1,0 +1,22 @@
+package me.saiintbrisson.minecraft;
+
+import org.bukkit.plugin.Plugin;
+
+public class DelegatedViewProvider implements ViewProvider {
+
+	private final ViewFrame frame;
+
+	public DelegatedViewProvider(ViewFrame viewFrame) {
+		this.frame = viewFrame;
+	}
+
+	@Override
+	public Plugin getHolder() {
+		return frame.getOwner();
+	}
+
+	@Override
+	public ViewFrame getFrame() {
+		return frame;
+	}
+}

--- a/src/main/java/me/saiintbrisson/minecraft/ViewFrame.java
+++ b/src/main/java/me/saiintbrisson/minecraft/ViewFrame.java
@@ -5,6 +5,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.ServicePriority;
+import org.bukkit.plugin.ServicesManager;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -90,8 +92,13 @@ public final class ViewFrame {
 		tryRegister(views);
 
 		this.listener = new ViewListener(this);
-		Bukkit.getPluginManager().registerEvents(listener, owner);
-		debug("[frame] registered to " + owner.getName());
+
+		if (ensureProvider()) {
+			Bukkit.getPluginManager().registerEvents(listener, owner);
+			debug("[frame] registered to " + owner.getName());
+		} else {
+			debug("[frame] provider already registered, we will not register again the View Listener. ");
+		}
 	}
 
 	/**
@@ -177,6 +184,18 @@ public final class ViewFrame {
 			return;
 
 		getOwner().getLogger().info("[IF DEBUG] " + message);
+	}
+
+	private boolean ensureProvider() {
+		ServicesManager servicesManager = Bukkit.getServicesManager();
+
+		if (!servicesManager.isProvidedFor(ViewProvider.class)) {
+			servicesManager.register(ViewProvider.class, new DelegatedViewProvider(this), owner, ServicePriority.Normal);
+
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/src/main/java/me/saiintbrisson/minecraft/ViewProvider.java
+++ b/src/main/java/me/saiintbrisson/minecraft/ViewProvider.java
@@ -1,0 +1,11 @@
+package me.saiintbrisson.minecraft;
+
+import org.bukkit.plugin.Plugin;
+
+public interface ViewProvider {
+
+	Plugin getHolder();
+
+	ViewFrame getFrame();
+
+}


### PR DESCRIPTION
Pessoalmente, eu costumo usar integrar toda a biblioteca do inventory-framework em um projeto único, mas isso provoca a execução de callbacks duplicados porque ao instanciar diversos ViewFrames as mesmas acabam duplicando o Listener do Bukkit.
O patch verifica se um registro anterior já está registrado nos serviços do Bukkit para impedir o registro do próximo listener que vai causar a duplicação.