### PR TITLE
Add `api-version` to plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 main: me.saiintbrisson.minecraft.InventoryFramework
 name: InventoryFramework
 version: @version@
+api-version: 1.16
 authors: [SaiintBrisson, DevNatan, sasuked]
 website: https://github.com/DevNatan/inventory-framework
 description: Bukkit Inventory API framework


### PR DESCRIPTION
Plugins not using the `api-version` in plugin.yml introduced in 1.13 may lead to load the old legacy support.
See: https://www.spigotmc.org/wiki/plugin-yml/#optional-attributes