### PR TITLE
Fix null slot context current item and pagination context slot

### DIFF
--- a/bukkit-api/src/main/java/me/saiintbrisson/minecraft/BukkitClickViewSlotContext.java
+++ b/bukkit-api/src/main/java/me/saiintbrisson/minecraft/BukkitClickViewSlotContext.java
@@ -3,36 +3,30 @@ package me.saiintbrisson.minecraft;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Bukkit platform ViewSlotClickContext implementation with click origin property.
+ */
 @Getter
 @Setter
 @ToString(callSuper = true, onlyExplicitlyIncluded = true)
-public class BukkitClickViewSlotContext extends AbstractViewSlotContext implements ViewSlotClickContext {
+public class BukkitClickViewSlotContext extends BukkitViewSlotContext implements ViewSlotClickContext {
 
     private final InventoryClickEvent clickOrigin;
 
     BukkitClickViewSlotContext(
-            ViewItem backingItem,
-            @NotNull BaseViewContext parent,
+            int slot,
             @NotNull InventoryClickEvent clickOrigin,
-            @NotNull ViewContainer container) {
-        super(backingItem, parent, container);
+            ViewItem backingItem,
+            ViewContext parent,
+            ViewContainer container) {
+        super(slot, backingItem, parent, container);
         this.clickOrigin = clickOrigin;
-    }
-
-    @Override
-    public final int getSlot() {
-        return getClickOrigin().getSlot();
-    }
-
-    @Override
-    public final @NotNull Player getPlayer() {
-        return (Player) clickOrigin.getWhoClicked();
+        this.item = new ItemWrapper(clickOrigin.getCurrentItem());
     }
 
     @Override
@@ -66,13 +60,8 @@ public class BukkitClickViewSlotContext extends AbstractViewSlotContext implemen
     }
 
     @Override
-    public @NotNull String getClickIdentifier() {
+    @NotNull
+    public final String getClickIdentifier() {
         return getClickOrigin().getClick().name();
-    }
-
-    @Override
-    public final void inventoryModificationTriggered() {
-        throw new IllegalStateException("You cannot update the item in the click handler context. "
-                + "Use the slot.onRender(...) or slot.onUpdate(...) and then context.setItem(...) instead.");
     }
 }

--- a/bukkit-api/src/main/java/me/saiintbrisson/minecraft/BukkitPaginatedViewSlotContextImpl.java
+++ b/bukkit-api/src/main/java/me/saiintbrisson/minecraft/BukkitPaginatedViewSlotContextImpl.java
@@ -6,10 +6,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.ToString;
-import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -22,39 +20,16 @@ import org.jetbrains.annotations.Nullable;
  */
 @Getter
 @ToString
-final class BukkitPaginatedViewSlotContextImpl<T> extends AbstractViewSlotContext
-        implements PaginatedViewSlotContext<T> {
+final class BukkitPaginatedViewSlotContextImpl<T> extends BukkitViewSlotContext implements PaginatedViewSlotContext<T> {
 
     private final int index;
     private final T value;
 
-    @Getter(AccessLevel.NONE)
-    private final PaginatedViewContext<T> parent;
-
     BukkitPaginatedViewSlotContextImpl(
-            int index, @NotNull T value, ViewItem backingItem, PaginatedViewContext<T> parent) {
-        super(backingItem, parent);
+            int index, T value, int slot, ViewItem backingItem, ViewContext parent, ViewContainer container) {
+        super(slot, backingItem, parent, container);
         this.index = index;
         this.value = value;
-        this.parent = parent;
-    }
-
-    @Override
-    public void inventoryModificationTriggered() {
-        throw new IllegalStateException(
-                "Direct container modifications are not allowed from a paginated context because "
-                        + "rendering a paginated item is an extensive method and can cause cyclic"
-                        + " rendering on update, when rendering a paginated view.");
-    }
-
-    @Override
-    public int getSlot() {
-        return index;
-    }
-
-    @Override
-    public @NotNull Player getPlayer() {
-        return BukkitViewer.toPlayerOfContext(this);
     }
 
     @Override
@@ -65,176 +40,176 @@ final class BukkitPaginatedViewSlotContextImpl<T> extends AbstractViewSlotContex
 
     @Override
     public void setSource(@NotNull List<? extends T> source) {
-        throwPaginationDataChangedError();
+        throwNotAllowedCall();
     }
 
     @Override
     public void setSource(@NotNull Function<PaginatedViewContext<T>, List<? extends T>> sourceProvider) {
-        throwPaginationDataChangedError();
+        throwNotAllowedCall();
     }
 
     @Override
     public AsyncPaginationDataState<T> setSourceAsync(
             @NotNull Function<PaginatedViewContext<T>, CompletableFuture<List<? extends T>>> sourceFuture) {
-        throwPaginationDataChangedError();
+        throwNotAllowedCall();
         return null;
     }
 
     @Override
     public void setPagesCount(int pagesCount) {
-        throwPaginationDataChangedError();
+        throwNotAllowedCall();
     }
 
     @Override
     public void setLayout(String... layout) {
-        throwPaginationDataChangedError();
+        throwNotAllowedCall();
     }
 
     @Override
     public void setLayout(char character, Supplier<ViewItem> factory) {
-        throwPaginationDataChangedError();
+        throwNotAllowedCall();
     }
 
     @Override
     public void setLayout(char character, Consumer<ViewItem> factory) {
-        throwPaginationDataChangedError();
+        throwNotAllowedCall();
     }
 
     @Override
     public Paginator<T> getPaginator() {
-        return parent.getPaginator();
+        return getParent().getPaginator();
     }
 
     @Override
     @Deprecated
     public int getPageSize() {
-        return parent.getPageSize();
+        return getParent().getPageSize();
     }
 
     @Override
     @Deprecated
     public int getPageMaxItemsCount() {
-        return parent.getPageMaxItemsCount();
+        return getParent().getPageMaxItemsCount();
     }
 
     @Override
     public @NotNull List<T> getSource() {
-        return parent.getSource();
+        return getParent().getSource();
     }
 
     @Override
     public int getPage() {
-        return parent.getPage();
+        return getParent().getPage();
     }
 
     @Override
     public void setPage(int page) {
-        parent.setPage(page);
+        getParent().setPage(page);
     }
 
     @Override
     public int getPagesCount() {
-        return parent.getPagesCount();
+        return getParent().getPagesCount();
     }
 
     @Override
     public int getPreviousPage() {
-        return parent.getPreviousPage();
+        return getParent().getPreviousPage();
     }
 
     @Override
     public int getNextPage() {
-        return parent.getNextPage();
+        return getParent().getNextPage();
     }
 
     @Override
     public boolean hasPreviousPage() {
-        return parent.hasPreviousPage();
+        return getParent().hasPreviousPage();
     }
 
     @Override
     public boolean hasNextPage() {
-        return parent.hasNextPage();
+        return getParent().hasNextPage();
     }
 
     @Override
     public boolean isFirstPage() {
-        return parent.isFirstPage();
+        return getParent().isFirstPage();
     }
 
     @Override
     public boolean isLastPage() {
-        return parent.isLastPage();
+        return getParent().isLastPage();
     }
 
     @Override
     public void switchTo(int page) {
-        parent.switchTo(page);
+        getParent().switchTo(page);
     }
 
     @Override
     public boolean switchToPreviousPage() {
-        return parent.switchToPreviousPage();
+        return getParent().switchToPreviousPage();
     }
 
     @Override
     public boolean switchToNextPage() {
-        return parent.switchToNextPage();
+        return getParent().switchToNextPage();
     }
 
     @Override
     public int getPreviousPageItemSlot() {
-        return parent.getPreviousPageItemSlot();
+        return getParent().getPreviousPageItemSlot();
     }
 
     @Override
     public void setPreviousPageItemSlot(int previousPageItemSlot) {
-        throwPaginationDataChangedError();
+        throwNotAllowedCall();
     }
 
     @Override
     public int getNextPageItemSlot() {
-        return parent.getNextPageItemSlot();
+        return getParent().getNextPageItemSlot();
     }
 
     @Override
     public void setNextPageItemSlot(int nextPageItemSlot) {
-        throwPaginationDataChangedError();
+        throwNotAllowedCall();
     }
 
     @Override
     public boolean isLayoutSignatureChecked() {
-        return parent.isLayoutSignatureChecked();
+        return getParent().isLayoutSignatureChecked();
     }
 
     @Override
     public void setLayoutSignatureChecked(boolean layoutSignatureChecked) {
-        throwPaginationDataChangedError();
+        throwNotAllowedCall();
     }
 
     @Override
     public BiConsumer<PaginatedViewContext<T>, ViewItem> getPreviousPageItemFactory() {
-        return parent.getPreviousPageItemFactory();
+        return getParent().getPreviousPageItemFactory();
     }
 
     @Override
     public BiConsumer<PaginatedViewContext<T>, ViewItem> getNextPageItemFactory() {
-        return parent.getNextPageItemFactory();
+        return getParent().getNextPageItemFactory();
     }
 
     @Override
     public @NotNull AbstractPaginatedView<T> getRoot() {
-        return parent.getRoot();
+        return getParent().getRoot();
     }
 
     @Override
     public void setPreviousPageItem(@NotNull BiConsumer<PaginatedViewContext<T>, ViewItem> previousPageItemFactory) {
-        throwPaginationDataChangedError();
+        throwNotAllowedCall();
     }
 
     @Override
     public void setNextPageItem(@NotNull BiConsumer<PaginatedViewContext<T>, ViewItem> nextPageItemFactory) {
-        throwPaginationDataChangedError();
+        throwNotAllowedCall();
     }
 
     @SuppressWarnings("unchecked")
@@ -243,8 +218,16 @@ final class BukkitPaginatedViewSlotContextImpl<T> extends AbstractViewSlotContex
         return this;
     }
 
-    private void throwPaginationDataChangedError() {
+    @Override
+    public PaginatedViewContext<T> getParent() {
+        return super.getParent().paginated();
+    }
+
+    @Override
+    public void inventoryModificationTriggered() {
         throw new IllegalStateException(
-                "It is not possible to change pagination data in a paginated item rendering context.");
+                "Direct container modifications are not allowed from a paginated context because "
+                        + "rendering a paginated item is an extensive method and can cause cyclic"
+                        + " rendering on update, when rendering a paginated view.");
     }
 }

--- a/bukkit-api/src/main/java/me/saiintbrisson/minecraft/BukkitViewComponentFactory.java
+++ b/bukkit-api/src/main/java/me/saiintbrisson/minecraft/BukkitViewComponentFactory.java
@@ -2,6 +2,7 @@ package me.saiintbrisson.minecraft;
 
 import static java.util.Objects.requireNonNull;
 import static me.saiintbrisson.minecraft.AbstractView.CLICK;
+import static me.saiintbrisson.minecraft.ViewItem.UNSET;
 import static org.bukkit.Bukkit.createInventory;
 
 import lombok.AccessLevel;
@@ -84,15 +85,13 @@ final class BukkitViewComponentFactory extends ViewComponentFactory {
                 : new ViewContextImpl(view, container);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     @NotNull
     public AbstractViewSlotContext createSlotContext(
-            ViewItem item, ViewContext parent, int paginatedItemIndex, Object paginatedItemValue) {
-        return paginatedItemValue == null
-                ? new BukkitViewSlotContext(item, parent)
-                : new BukkitPaginatedViewSlotContextImpl<>(
-                        paginatedItemIndex, paginatedItemValue, item, (PaginatedViewContext) parent);
+            int slot, ViewItem item, ViewContext parent, ViewContainer container, int index, Object value) {
+        return index == UNSET
+                ? new BukkitViewSlotContext(slot, item, parent, container)
+                : new BukkitPaginatedViewSlotContextImpl<>(index, value, slot, item, parent, container);
     }
 
     @Override

--- a/bukkit-api/src/main/java/me/saiintbrisson/minecraft/BukkitViewSlotContext.java
+++ b/bukkit-api/src/main/java/me/saiintbrisson/minecraft/BukkitViewSlotContext.java
@@ -6,21 +6,21 @@ import lombok.ToString;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Bukkit platform ViewSlotContext implementation.
+ */
 @Getter
 @Setter
 @ToString(callSuper = true, onlyExplicitlyIncluded = true)
 public class BukkitViewSlotContext extends AbstractViewSlotContext {
 
-    BukkitViewSlotContext(ViewItem backingItem, @NotNull ViewContext parent) {
-        super(backingItem, parent);
-    }
-
-    public int getSlot() {
-        return getBackingItem().getSlot();
+    BukkitViewSlotContext(int slot, ViewItem backingItem, @NotNull ViewContext parent, ViewContainer container) {
+        super(slot, backingItem, parent, container);
     }
 
     @Override
-    public @NotNull Player getPlayer() {
+    @NotNull
+    public final Player getPlayer() {
         return BukkitViewer.toPlayerOfContext(this);
     }
 }

--- a/bukkit-api/src/main/java/me/saiintbrisson/minecraft/ViewListener.java
+++ b/bukkit-api/src/main/java/me/saiintbrisson/minecraft/ViewListener.java
@@ -104,8 +104,11 @@ class ViewListener implements Listener {
         final ViewContainer container =
                 !isEntityContainer ? context.getContainer() : new BukkitEntityViewContainer(player.getInventory());
 
-        final ViewSlotContext slotContext = new BukkitClickViewSlotContext(
-                context.resolve(event.getSlot(), true, isEntityContainer), context, event, container);
+        final ViewItem item = context.resolve(event.getSlot(), true, isEntityContainer);
+
+        // TODO use platform to create this instance
+        final ViewSlotContext slotContext =
+                new BukkitClickViewSlotContext(event.getSlot(), event, item, context, container);
 
         try {
             view.runCatching(context, () -> view.getPipeline().execute(AbstractView.CLICK, slotContext));

--- a/feature-move-io/src/main/java/me/saiintbrisson/minecraft/BukkitMoveOutInterceptor.java
+++ b/feature-move-io/src/main/java/me/saiintbrisson/minecraft/BukkitMoveOutInterceptor.java
@@ -45,17 +45,17 @@ public final class BukkitMoveOutInterceptor implements PipelineInterceptor<Bukki
 
         if (hold == null) return;
 
-        final ViewSlotMoveContext moveContext = new ViewSlotMoveContextImpl(
+        final ViewSlotMoveContext moveContext = new BukkitViewSlotMoveClickContextImpl(
+                event,
                 hold,
                 subject,
-                event,
                 container,
                 event.getCursor(),
                 swappedItem,
+                hold.getSlot(),
                 event.getSlot(),
                 swappedItem != null,
                 false);
-
         moveContext.setCancelled(subject.isCancelled());
         if (hold.getMoveOutHandler() != null) hold.getMoveInHandler().accept(moveContext);
 

--- a/feature-move-io/src/main/java/me/saiintbrisson/minecraft/BukkitViewSlotMoveClickContextImpl.java
+++ b/feature-move-io/src/main/java/me/saiintbrisson/minecraft/BukkitViewSlotMoveClickContextImpl.java
@@ -7,31 +7,34 @@ import org.jetbrains.annotations.NotNull;
 
 @Getter
 @ToString(callSuper = true)
-final class ViewSlotMoveContextImpl extends BukkitClickViewSlotContext implements ViewSlotMoveContext {
+final class BukkitViewSlotMoveClickContextImpl extends BukkitClickViewSlotContext implements ViewSlotMoveContext {
 
-    @ToString.Exclude
-    private final ViewContainer targetContainer;
-
-    private final ItemWrapper targetItem, swappedItem;
     private final int targetSlot;
+    private final ItemWrapper targetItem, swappedItem;
     private final boolean swap, stack;
 
-    ViewSlotMoveContextImpl(
-            ViewItem backingItem,
-            @NotNull BaseViewContext parent,
+    BukkitViewSlotMoveClickContextImpl(
             @NotNull InventoryClickEvent clickOrigin,
-            ViewContainer targetContainer,
+            ViewItem backingItem,
+            ViewContext parent,
+            ViewContainer container,
             Object targetItem,
             Object swappedItem,
+            int slot,
             int targetSlot,
             boolean swap,
             boolean stack) {
-        super(backingItem, parent, clickOrigin, targetContainer);
-        this.targetContainer = targetContainer;
+        super(slot, clickOrigin, backingItem, parent, container);
+        this.targetSlot = targetSlot;
         this.targetItem = new ItemWrapper(targetItem);
         this.swappedItem = new ItemWrapper(swappedItem);
-        this.targetSlot = targetSlot;
         this.swap = swap;
         this.stack = stack;
+    }
+
+    @Override
+    public @NotNull ViewContainer getTargetContainer() {
+        // there's no way to determine target container for now :(
+        return getContainer();
     }
 }

--- a/shared/src/main/java/me/saiintbrisson/minecraft/AbstractView.java
+++ b/shared/src/main/java/me/saiintbrisson/minecraft/AbstractView.java
@@ -389,8 +389,8 @@ public abstract class AbstractView extends AbstractVirtualView {
 
     public final void registerContext(@NotNull ViewContext context) {
         synchronized (contexts) {
-			contexts.add(context);
-		}
+            contexts.add(context);
+        }
     }
 
     public final boolean isCancelOnClick() {
@@ -712,8 +712,8 @@ public abstract class AbstractView extends AbstractVirtualView {
     @ApiStatus.Internal
     public final boolean triggerSlotRender(ViewContext parent, ViewSlotContext context, ViewItem item, int slot) {
         final ViewSlotContext renderContext = context == null
-			? PlatformUtils.getFactory().createSlotContext(slot, item, parent, parent.getContainer(), UNSET, null)
-			: context;
+                ? PlatformUtils.getFactory().createSlotContext(slot, item, parent, parent.getContainer(), UNSET, null)
+                : context;
 
         runCatching(context, () -> onSlotRender(renderContext));
 
@@ -789,8 +789,8 @@ public abstract class AbstractView extends AbstractVirtualView {
         }
 
         if (item.getUpdateHandler() != null) {
-            final ViewSlotContext updateContext =
-                    PlatformUtils.getFactory().createSlotContext(slot, item, context, context.getContainer(), UNSET, null);
+            final ViewSlotContext updateContext = PlatformUtils.getFactory()
+                    .createSlotContext(slot, item, context, context.getContainer(), UNSET, null);
 
             runCatching(context, () -> item.getUpdateHandler().handle(updateContext));
             if (updateContext.hasChanged()) {

--- a/shared/src/main/java/me/saiintbrisson/minecraft/AbstractView.java
+++ b/shared/src/main/java/me/saiintbrisson/minecraft/AbstractView.java
@@ -1,6 +1,7 @@
 package me.saiintbrisson.minecraft;
 
 import static me.saiintbrisson.minecraft.IFUtils.unwrap;
+import static me.saiintbrisson.minecraft.ViewItem.UNSET;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -137,6 +138,17 @@ public abstract class AbstractView extends AbstractVirtualView {
      * @param context The player view context.
      */
     protected void onRender(@NotNull ViewContext context) {}
+
+    /**
+     * Called when a slot (even if it's a pseudo slot) is rendered.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param context The slot render context.
+     */
+    @ApiStatus.Experimental
+    protected void onSlotRender(@NotNull ViewSlotContext context) {}
 
     /**
      * Called when the view is updated for a player.
@@ -697,6 +709,25 @@ public abstract class AbstractView extends AbstractVirtualView {
         return ViewItem.AVAILABLE;
     }
 
+    @ApiStatus.Internal
+    public final boolean triggerSlotRender(ViewContext parent, ViewSlotContext context, ViewItem item, int slot) {
+        final ViewSlotContext renderContext = context == null
+			? PlatformUtils.getFactory().createSlotContext(slot, item, parent, parent.getContainer(), UNSET, null)
+			: context;
+
+        runCatching(context, () -> onSlotRender(renderContext));
+
+        if (item != null) runCatching(context, () -> item.getRenderHandler().handle(renderContext));
+
+        if (renderContext.hasChanged()) {
+            renderContext.getContainer().renderItem(slot, unwrap(renderContext.getItemWrapper()));
+            renderContext.setChanged(false);
+            return true;
+        }
+
+        return false;
+    }
+
     /**
      * Renders a item.
      *
@@ -718,14 +749,8 @@ public abstract class AbstractView extends AbstractVirtualView {
         final Object fallbackItem = item.getItem();
 
         if (item.getRenderHandler() != null) {
-            final ViewSlotContext renderContext = PlatformUtils.getFactory().createSlotContext(item, context, 0, null);
-
-            runCatching(context, () -> item.getRenderHandler().handle(renderContext));
-            if (renderContext.hasChanged()) {
-                context.getContainer().renderItem(slot, unwrap(renderContext.getItemWrapper()));
-                renderContext.setChanged(false);
-                return;
-            }
+            final boolean modified = triggerSlotRender(context, null, item, slot);
+            if (modified) return;
         }
 
         if (fallbackItem == null)
@@ -764,7 +789,8 @@ public abstract class AbstractView extends AbstractVirtualView {
         }
 
         if (item.getUpdateHandler() != null) {
-            final ViewSlotContext updateContext = PlatformUtils.getFactory().createSlotContext(item, context, 0, null);
+            final ViewSlotContext updateContext =
+                    PlatformUtils.getFactory().createSlotContext(slot, item, context, context.getContainer(), UNSET, null);
 
             runCatching(context, () -> item.getUpdateHandler().handle(updateContext));
             if (updateContext.hasChanged()) {
@@ -911,14 +937,12 @@ public abstract class AbstractView extends AbstractVirtualView {
         setInitialized(true);
     }
 
-    /** {@inheritDoc} */
     @Override
     public void emit(@NotNull String event, Object value) {
         super.emit(event, value);
         getContexts().forEach(context -> context.emit(event, value));
     }
 
-    /** {@inheritDoc} */
     @Override
     public void emit(@NotNull Object event) {
         super.emit(event);

--- a/shared/src/main/java/me/saiintbrisson/minecraft/BaseViewContext.java
+++ b/shared/src/main/java/me/saiintbrisson/minecraft/BaseViewContext.java
@@ -16,6 +16,8 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static me.saiintbrisson.minecraft.ViewItem.UNSET;
+
 @Getter
 @Setter
 @ToString(callSuper = true)
@@ -291,7 +293,7 @@ public class BaseViewContext extends AbstractVirtualView implements ViewContext 
             throw new IllegalStateException(
                     "Tried to get a slot reference while context framework was not registered yet");
 
-        return vf.getFactory().createSlotContext(item, this, 0, null);
+        return vf.getFactory().createSlotContext(item.getSlot(), item, this, getContainer(), UNSET, null);
     }
 
     @Override

--- a/shared/src/main/java/me/saiintbrisson/minecraft/BaseViewContext.java
+++ b/shared/src/main/java/me/saiintbrisson/minecraft/BaseViewContext.java
@@ -1,5 +1,7 @@
 package me.saiintbrisson.minecraft;
 
+import static me.saiintbrisson.minecraft.ViewItem.UNSET;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -15,8 +17,6 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import static me.saiintbrisson.minecraft.ViewItem.UNSET;
 
 @Getter
 @Setter

--- a/shared/src/main/java/me/saiintbrisson/minecraft/ItemWrapper.java
+++ b/shared/src/main/java/me/saiintbrisson/minecraft/ItemWrapper.java
@@ -18,7 +18,6 @@ public final class ItemWrapper {
 
     ItemWrapper(@Nullable Object value) {
         this.value = value instanceof ItemWrapper ? ((ItemWrapper) value).getValue() : value;
-
         checkValueType();
     }
 

--- a/shared/src/main/java/me/saiintbrisson/minecraft/PaginatedViewSlotContext.java
+++ b/shared/src/main/java/me/saiintbrisson/minecraft/PaginatedViewSlotContext.java
@@ -13,6 +13,9 @@ import org.jetbrains.annotations.Nullable;
  */
 public interface PaginatedViewSlotContext<T> extends PaginatedViewContext<T>, ViewSlotContext {
 
+    @Override
+    PaginatedViewContext<T> getParent();
+
     /**
      * The position that the current item is in relation to the pagination. Please don't confuse with
      * the position of the item in the container, this is {@link #getSlot()}.

--- a/shared/src/main/java/me/saiintbrisson/minecraft/UnmodifiableViewContext.java
+++ b/shared/src/main/java/me/saiintbrisson/minecraft/UnmodifiableViewContext.java
@@ -1,0 +1,12 @@
+package me.saiintbrisson.minecraft;
+
+/**
+ * Mark interface that throws an exception when an inventory modification is triggered.
+ */
+public interface UnmodifiableViewContext extends ViewContext {
+
+    @Override
+    default void inventoryModificationTriggered() {
+        throw new IllegalStateException("Not allowed to modify the inventory in this context.");
+    }
+}

--- a/shared/src/main/java/me/saiintbrisson/minecraft/ViewComponentFactory.java
+++ b/shared/src/main/java/me/saiintbrisson/minecraft/ViewComponentFactory.java
@@ -53,7 +53,7 @@ public abstract class ViewComponentFactory {
 
     @NotNull
     public abstract AbstractViewSlotContext createSlotContext(
-            ViewItem item, ViewContext parent, int paginatedItemIndex, Object paginatedItemValue);
+            int slot, ViewItem item, ViewContext parent, ViewContainer container, int index, Object value);
 
     public abstract Object createItem(@Nullable Object stack);
 

--- a/shared/src/main/java/me/saiintbrisson/minecraft/ViewSlotClickContext.java
+++ b/shared/src/main/java/me/saiintbrisson/minecraft/ViewSlotClickContext.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @see ViewSlotContext
  */
-public interface ViewSlotClickContext extends ViewSlotContext {
+public interface ViewSlotClickContext extends ViewSlotContext, UnmodifiableViewContext {
 
     /**
      * If the click was using the left mouse button.

--- a/shared/src/main/java/me/saiintbrisson/minecraft/ViewSlotContext.java
+++ b/shared/src/main/java/me/saiintbrisson/minecraft/ViewSlotContext.java
@@ -39,7 +39,10 @@ public interface ViewSlotContext extends ViewContext {
      * Clears this slot from the current context.
      * <p>
      * The slot will only be cleaned on the next update, so if you want it cleaned immediately
-     * update the slot using {@link #updateSlot()}
+     * update the slot using {@link #updateSlot()}.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
      */
     @ApiStatus.Experimental
     void clear();
@@ -219,4 +222,11 @@ public interface ViewSlotContext extends ViewContext {
      */
     @Override
     <T> PaginatedViewContext<T> paginated();
+
+    /**
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     */
+    @ApiStatus.Experimental
+    boolean isRegistered();
 }

--- a/shared/src/main/java/me/saiintbrisson/minecraft/pipeline/interceptors/PaginationRenderInterceptor.java
+++ b/shared/src/main/java/me/saiintbrisson/minecraft/pipeline/interceptors/PaginationRenderInterceptor.java
@@ -211,7 +211,7 @@ public final class PaginationRenderInterceptor implements PipelineInterceptor<Vi
 
             @SuppressWarnings("unchecked")
             final PaginatedViewSlotContext<T> slotContext = (PaginatedViewSlotContext<T>)
-                    PlatformUtils.getFactory().createSlotContext(item, context, index, value);
+                    PlatformUtils.getFactory().createSlotContext(slot, item, context, context.getContainer(), index, value);
 
             context.getRoot().runCatching(context, () -> context.getRoot().callItemRender(slotContext, item, value));
             renderItemAndApplyOnContext(context, item, slot);

--- a/shared/src/main/java/me/saiintbrisson/minecraft/pipeline/interceptors/PaginationRenderInterceptor.java
+++ b/shared/src/main/java/me/saiintbrisson/minecraft/pipeline/interceptors/PaginationRenderInterceptor.java
@@ -210,8 +210,8 @@ public final class PaginationRenderInterceptor implements PipelineInterceptor<Vi
             item.setPaginationItem(true);
 
             @SuppressWarnings("unchecked")
-            final PaginatedViewSlotContext<T> slotContext = (PaginatedViewSlotContext<T>)
-                    PlatformUtils.getFactory().createSlotContext(slot, item, context, context.getContainer(), index, value);
+            final PaginatedViewSlotContext<T> slotContext = (PaginatedViewSlotContext<T>) PlatformUtils.getFactory()
+                    .createSlotContext(slot, item, context, context.getContainer(), index, value);
 
             context.getRoot().runCatching(context, () -> context.getRoot().callItemRender(slotContext, item, value));
             renderItemAndApplyOnContext(context, item, slot);

--- a/shared/src/main/java/me/saiintbrisson/minecraft/pipeline/interceptors/RenderInterceptor.java
+++ b/shared/src/main/java/me/saiintbrisson/minecraft/pipeline/interceptors/RenderInterceptor.java
@@ -31,7 +31,10 @@ public final class RenderInterceptor implements PipelineInterceptor<VirtualView>
         for (int i = 0; i < len; i++) {
             // this resolve will get the items from both root and context, so we render both
             final ViewItem item = context.resolve(i, true);
-            if (item == null) continue;
+            if (item == null) {
+                root.triggerSlotRender(context, null, null, i);
+                continue;
+            }
 
             root.render(context, item, i);
         }

--- a/shared/src/main/java/me/saiintbrisson/minecraft/pipeline/interceptors/UpdateInterceptor.java
+++ b/shared/src/main/java/me/saiintbrisson/minecraft/pipeline/interceptors/UpdateInterceptor.java
@@ -23,8 +23,7 @@ public final class UpdateInterceptor implements PipelineInterceptor<VirtualView>
 
         final AbstractView root = context.getRoot();
 
-        // we prioritize the amount of items in the context because the priority is in the context
-        // and the size of items in the context is proportional to the size of its container
+        // size of items in the context is proportional to the size of its container
         final int len = context.getContainer().getSize();
 
         for (int i = 0; i < len; i++) {
@@ -32,7 +31,11 @@ public final class UpdateInterceptor implements PipelineInterceptor<VirtualView>
             final ViewItem item = context.resolve(i, true);
 
             if (item == null) {
-                context.getContainer().removeItem(i);
+                final boolean modified = root.triggerSlotRender(context, null, null, i);
+
+                // default behavior if slot render wasn't modified
+                if (!modified) context.getContainer().removeItem(i);
+
                 continue;
             }
 

--- a/shared/src/test/java/me/saiintbrisson/minecraft/ContextDataInheritanceTest.java
+++ b/shared/src/test/java/me/saiintbrisson/minecraft/ContextDataInheritanceTest.java
@@ -20,12 +20,7 @@ public class ContextDataInheritanceTest {
         when(parentContext.getData()).thenReturn(data);
 
         AbstractViewSlotContext slotContext =
-                new AbstractViewSlotContext(new ViewItem(), parentContext, parentContext.getContainer()) {
-                    @Override
-                    public int getSlot() {
-                        return 0;
-                    }
-                };
+                new AbstractViewSlotContext(0, new ViewItem(), parentContext, parentContext.getContainer()) {};
         assertEquals(
                 parentContext.get(key),
                 (String) slotContext.get(key),
@@ -37,12 +32,7 @@ public class ContextDataInheritanceTest {
         String key = "inherited";
         ViewContext parentContext = mock(BaseViewContext.class);
         AbstractViewSlotContext slotContext =
-                new AbstractViewSlotContext(new ViewItem(), parentContext, parentContext.getContainer()) {
-                    @Override
-                    public int getSlot() {
-                        return 0;
-                    }
-                };
+                new AbstractViewSlotContext(0, new ViewItem(), parentContext, parentContext.getContainer()) {};
         slotContext.set(key, "value");
         assertEquals(
                 slotContext.get(key),

--- a/shared/src/test/java/me/saiintbrisson/minecraft/ContextDataInheritanceTest.java
+++ b/shared/src/test/java/me/saiintbrisson/minecraft/ContextDataInheritanceTest.java
@@ -19,12 +19,13 @@ public class ContextDataInheritanceTest {
         ViewContext parentContext = mock(BaseViewContext.class);
         when(parentContext.getData()).thenReturn(data);
 
-        AbstractViewSlotContext slotContext = new AbstractViewSlotContext(new ViewItem(), parentContext) {
-            @Override
-            public int getSlot() {
-                return 0;
-            }
-        };
+        AbstractViewSlotContext slotContext =
+                new AbstractViewSlotContext(new ViewItem(), parentContext, parentContext.getContainer()) {
+                    @Override
+                    public int getSlot() {
+                        return 0;
+                    }
+                };
         assertEquals(
                 parentContext.get(key),
                 (String) slotContext.get(key),
@@ -35,12 +36,13 @@ public class ContextDataInheritanceTest {
     void shouldSlotContextPropagateDataToParent() {
         String key = "inherited";
         ViewContext parentContext = mock(BaseViewContext.class);
-        AbstractViewSlotContext slotContext = new AbstractViewSlotContext(new ViewItem(), parentContext) {
-            @Override
-            public int getSlot() {
-                return 0;
-            }
-        };
+        AbstractViewSlotContext slotContext =
+                new AbstractViewSlotContext(new ViewItem(), parentContext, parentContext.getContainer()) {
+                    @Override
+                    public int getSlot() {
+                        return 0;
+                    }
+                };
         slotContext.set(key, "value");
         assertEquals(
                 slotContext.get(key),

--- a/shared/src/test/java/me/saiintbrisson/minecraft/MockComponentFactory.java
+++ b/shared/src/test/java/me/saiintbrisson/minecraft/MockComponentFactory.java
@@ -33,7 +33,7 @@ public class MockComponentFactory extends ViewComponentFactory {
 
     @Override
     public @NotNull AbstractViewSlotContext createSlotContext(
-            ViewItem item, ViewContext parent, int paginatedItemIndex, Object paginatedItemValue) {
+            int slot, ViewItem item, ViewContext parent, int paginatedItemIndex, Object paginatedItemValue) {
         return mock(AbstractViewSlotContext.class);
     }
 

--- a/shared/src/test/java/me/saiintbrisson/minecraft/MockComponentFactory.java
+++ b/shared/src/test/java/me/saiintbrisson/minecraft/MockComponentFactory.java
@@ -33,7 +33,7 @@ public class MockComponentFactory extends ViewComponentFactory {
 
     @Override
     public @NotNull AbstractViewSlotContext createSlotContext(
-            int slot, ViewItem item, ViewContext parent, int paginatedItemIndex, Object paginatedItemValue) {
+            int slot, ViewItem item, ViewContext parent, ViewContainer container, int index, Object value) {
         return mock(AbstractViewSlotContext.class);
     }
 

--- a/shared/src/test/java/me/saiintbrisson/minecraft/NoopViewComponentFactory.java
+++ b/shared/src/test/java/me/saiintbrisson/minecraft/NoopViewComponentFactory.java
@@ -33,7 +33,7 @@ public abstract class NoopViewComponentFactory extends ViewComponentFactory {
 
     @Override
     public @NotNull AbstractViewSlotContext createSlotContext(
-            int slot, ViewItem item, ViewContext parent, int paginatedItemIndex, Object paginatedItemValue) {
+            int slot, ViewItem item, ViewContext parent, ViewContainer container, int index, Object value) {
         throw new UnsupportedOperationException();
     }
 

--- a/shared/src/test/java/me/saiintbrisson/minecraft/NoopViewComponentFactory.java
+++ b/shared/src/test/java/me/saiintbrisson/minecraft/NoopViewComponentFactory.java
@@ -33,7 +33,7 @@ public abstract class NoopViewComponentFactory extends ViewComponentFactory {
 
     @Override
     public @NotNull AbstractViewSlotContext createSlotContext(
-            ViewItem item, ViewContext parent, int paginatedItemIndex, Object paginatedItemValue) {
+            int slot, ViewItem item, ViewContext parent, int paginatedItemIndex, Object paginatedItemValue) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
* Allows nullable values on pagination sources
* Fixes pagination context `getSlot()` returning index instead of current slot
* Fixes context `getCurrentItem`
* New `onSlotRender` prototype
* Now supports immediate `clear()` when context is on entity container

Closes #230, #223