### PR TITLE
Wait for interval before start scheduled update job

### DIFF
--- a/bukkit/src/main/java/me/devnatan/inventoryframework/internal/BukkitTaskJobImpl.java
+++ b/bukkit/src/main/java/me/devnatan/inventoryframework/internal/BukkitTaskJobImpl.java
@@ -20,7 +20,7 @@ class BukkitTaskJobImpl implements Job {
     @Override
     public void start() {
         if (isStarted()) return;
-        task = plugin.getServer().getScheduler().runTaskTimer(plugin, this::loop, 0, intervalInTicks);
+        task = plugin.getServer().getScheduler().runTaskTimer(plugin, this::loop, intervalInTicks, intervalInTicks);
     }
 
     @Override


### PR DESCRIPTION
Caused an "immediate update" and the initially defined title was not visible.