### PR TITLE
Per-viewer state management

### DIFF
--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/BukkitViewer.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/BukkitViewer.java
@@ -4,15 +4,16 @@ import java.util.Deque;
 import java.util.LinkedList;
 import java.util.Objects;
 import me.devnatan.inventoryframework.context.IFRenderContext;
+import me.devnatan.inventoryframework.state.DefaultStateValueHost;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-public final class BukkitViewer implements Viewer {
+public final class BukkitViewer extends DefaultStateValueHost implements Viewer {
 
     private final Player player;
     private ViewContainer selfContainer;
     private IFRenderContext activeContext;
-    private Deque<IFRenderContext> previousContexts = new LinkedList<>();
+    private final Deque<IFRenderContext> previousContexts = new LinkedList<>();
     private long lastInteractionInMillis;
     private boolean transitioning;
 


### PR DESCRIPTION
Allows the use of state for a single player instead of all players in a context. Designed to use with [shared contexts](https://github.com/DevNatan/inventory-framework/wiki/Shared-Contexts).

**Not tested - Extremelly experimental** 
```java
myState.get(ctx.getViewer())...
```