### PR TITLE
Dynamically rendered items in pagination being positioned in the wrong place

### DIFF
--- a/api/src/main/java/me/devnatan/inventoryframework/component/Component.java
+++ b/api/src/main/java/me/devnatan/inventoryframework/component/Component.java
@@ -5,6 +5,7 @@ import me.devnatan.inventoryframework.VirtualView;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.context.IFSlotRenderContext;
 import me.devnatan.inventoryframework.state.State;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnmodifiableView;
 
@@ -89,4 +90,11 @@ public interface Component extends VirtualView {
      * @return If this component is visible.
      */
     boolean isVisible();
+
+    /**
+     * <p><b><i>This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided.</i></b>
+     */
+    @ApiStatus.Internal
+    boolean isManagedExternally();
 }

--- a/api/src/main/java/me/devnatan/inventoryframework/component/ComponentBuilder.java
+++ b/api/src/main/java/me/devnatan/inventoryframework/component/ComponentBuilder.java
@@ -1,6 +1,7 @@
 package me.devnatan.inventoryframework.component;
 
 import me.devnatan.inventoryframework.state.State;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -88,4 +89,11 @@ public interface ComponentBuilder<S extends ComponentBuilder<S>> {
      * @return A copy of this component builder.
      */
     S copy();
+
+    /**
+     * <p><b><i>This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided.</i></b>
+     */
+    @ApiStatus.Internal
+    S withExternallyManaged(boolean isExternallyManaged);
 }

--- a/bukkit/src/main/java/me/devnatan/inventoryframework/component/BukkitItemComponentBuilder.java
+++ b/bukkit/src/main/java/me/devnatan/inventoryframework/component/BukkitItemComponentBuilder.java
@@ -186,18 +186,20 @@ public final class BukkitItemComponentBuilder extends DefaultComponentBuilder<Bu
                 root,
                 slot,
                 item,
-                isCancelOnClick(),
-                isCloseOnClick(),
+                cancelOnClick,
+                closeOnClick,
                 shouldRender,
                 renderHandler,
                 updateHandler,
                 clickHandler,
-                getWatching());
+                watching,
+                isManagedExternally);
     }
 
     @Override
     public BukkitItemComponentBuilder copy() {
         return new BukkitItemComponentBuilder(
-                root, slot, item, renderHandler, clickHandler, updateHandler, shouldRender);
+                        root, slot, item, renderHandler, clickHandler, updateHandler, shouldRender)
+                .withExternallyManaged(isManagedExternally);
     }
 }

--- a/framework/src/main/java/me/devnatan/inventoryframework/component/DefaultComponentBuilder.java
+++ b/framework/src/main/java/me/devnatan/inventoryframework/component/DefaultComponentBuilder.java
@@ -11,30 +11,11 @@ import org.jetbrains.annotations.NotNull;
 @SuppressWarnings("unchecked")
 abstract class DefaultComponentBuilder<S extends ComponentBuilder<S>> implements ComponentBuilder<S> {
 
-    private String referenceKey;
-    private Map<String, Object> data;
-    private boolean cancelOnClick, closeOnClick;
-    private final Set<State<?>> watching = new LinkedHashSet<>();
-
-    protected final String getReferenceKey() {
-        return referenceKey;
-    }
-
-    protected final Map<String, Object> getData() {
-        return data;
-    }
-
-    protected final boolean isCancelOnClick() {
-        return cancelOnClick;
-    }
-
-    protected final boolean isCloseOnClick() {
-        return closeOnClick;
-    }
-
-    protected final Set<State<?>> getWatching() {
-        return watching;
-    }
+    protected String referenceKey;
+    protected Map<String, Object> data;
+    protected boolean cancelOnClick, closeOnClick;
+    protected final Set<State<?>> watching = new LinkedHashSet<>();
+    protected boolean isManagedExternally;
 
     @Override
     public S referencedBy(@NotNull String key) {
@@ -64,6 +45,12 @@ abstract class DefaultComponentBuilder<S extends ComponentBuilder<S>> implements
     @Override
     public S watch(State<?>... states) {
         watching.addAll(Arrays.asList(states));
+        return (S) this;
+    }
+
+    @Override
+    public S withExternallyManaged(boolean isExternallyManaged) {
+        isManagedExternally = isExternallyManaged;
         return (S) this;
     }
 }

--- a/framework/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/framework/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -403,7 +403,9 @@ public class PaginationImpl extends StateValue implements Pagination, Interactio
         for (final int position : layoutSlot.getPositions()) {
             final Object value = elements.get(iterationIndex++);
             final ComponentFactory factory = elementFactory.create(context, iterationIndex, position, value);
-            getComponentsInternal().add(factory.create());
+            final Component component = factory.create();
+
+            getComponentsInternal().add(component);
 
             if (iterationIndex == elementsLen) break;
         }
@@ -458,6 +460,11 @@ public class PaginationImpl extends StateValue implements Pagination, Interactio
                 break;
             }
         }
+    }
+
+    @Override
+    public boolean isManagedExternally() {
+        return true;
     }
 
     @VisibleForTesting

--- a/platform/src/main/java/me/devnatan/inventoryframework/PaginationStateBuilder.java
+++ b/platform/src/main/java/me/devnatan/inventoryframework/PaginationStateBuilder.java
@@ -78,7 +78,7 @@ public final class PaginationStateBuilder<
         return elementFactory((context, index, slot, value) -> {
             @SuppressWarnings("unchecked")
             B builder = (B) root.getElementFactory().createComponentBuilder(context);
-            builder.withSlot(slot);
+            builder.withSlot(slot).withExternallyManaged(true);
             itemFactory.accept(builder, value);
             return builder;
         });

--- a/platform/src/main/java/me/devnatan/inventoryframework/context/PlatformRenderContext.java
+++ b/platform/src/main/java/me/devnatan/inventoryframework/context/PlatformRenderContext.java
@@ -76,7 +76,8 @@ abstract class PlatformRenderContext<T extends ItemComponentBuilder<T>> extends 
      * This function is for creating items whose slot is set dynamically during item rendering.
      * <pre>{@code
      * unsetSlot().onRender(render -> {
-     *     render.withSlot(...);
+     *     render.setItem(...);
+     *     render.setSlot(...);
      * });
      * }</pre>
      *

--- a/test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
+++ b/test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
@@ -14,7 +14,6 @@ public class FakeComponent implements Component, InteractionHandler {
 
     private final VirtualView root;
     private int position = 0;
-    private boolean markedForRemoval = false;
     public Object item = new Object();
 
     public FakeComponent(VirtualView root) {
@@ -72,6 +71,11 @@ public class FakeComponent implements Component, InteractionHandler {
     @Override
     public boolean isVisible() {
         return true;
+    }
+
+    @Override
+    public boolean isManagedExternally() {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Dynamically rendered items (`renderWith`/`onRender`) when used in `paginationState`, where placed in the wrong position.

**Reproducible code**
Works with or without layout.

```java
private final State<Pagination> paginationState = paginationState(
    (context) -> <any non-empty source here>,
    (item, value) -> item.renderWith(() -> new ItemStack(Material.PAPER))
);

@Override
public void onInit(ViewConfigBuilder config) {
    config.cancelOnClick().layout(
	"         ",
	" OOOOOOO ",
	"         "
    );
}
```

| Before | After |
|:-:|:-:|
| ![image](https://github.com/DevNatan/inventory-framework/assets/24600258/51ce45b9-e5f6-4c4a-9fda-fa80ae818447) | ![image](https://github.com/DevNatan/inventory-framework/assets/24600258/89c94e52-e110-4839-b8dc-be7feffa54e3) |


