### PR TITLE
Create updateOnClick() overload

### DIFF
--- a/api/src/main/java/me/devnatan/inventoryframework/component/ComponentBuilder.java
+++ b/api/src/main/java/me/devnatan/inventoryframework/component/ComponentBuilder.java
@@ -96,4 +96,15 @@ public interface ComponentBuilder<S extends ComponentBuilder<S>> {
      */
     @ApiStatus.Internal
     S withExternallyManaged(boolean isExternallyManaged);
+
+    /**
+     * Updates the current context when a player clicks on this component.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @return This component builder.
+     */
+    @ApiStatus.Experimental
+    S updateOnClick();
 }

--- a/api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
+++ b/api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
@@ -29,6 +29,7 @@ public class ItemComponent implements Component, InteractionHandler {
     private final Consumer<? super IFSlotClickContext> clickHandler;
     private final Set<State<?>> watching;
     private final boolean isManagedExternally;
+    private final boolean updateOnClick;
 
     public ItemComponent(
             VirtualView root,
@@ -41,7 +42,8 @@ public class ItemComponent implements Component, InteractionHandler {
             Consumer<? super IFSlotContext> updateHandler,
             Consumer<? super IFSlotClickContext> clickHandler,
             Set<State<?>> watching,
-            boolean isManagedExternally) {
+            boolean isManagedExternally,
+            boolean updateOnClick) {
         this.root = root;
         this.position = position;
         this.stack = stack;
@@ -53,6 +55,7 @@ public class ItemComponent implements Component, InteractionHandler {
         this.clickHandler = clickHandler;
         this.watching = watching;
         this.isManagedExternally = isManagedExternally;
+        this.updateOnClick = updateOnClick;
     }
 
     @NotNull
@@ -76,6 +79,10 @@ public class ItemComponent implements Component, InteractionHandler {
 
     public boolean isCloseOnClick() {
         return closeOnClick;
+    }
+
+    public boolean isUpdateOnClick() {
+        return updateOnClick;
     }
 
     public BooleanSupplier getShouldRender() {
@@ -166,6 +173,7 @@ public class ItemComponent implements Component, InteractionHandler {
     public void clicked(@NotNull Component component, @NotNull IFSlotClickContext context) {
         if (clickHandler == null) return;
         clickHandler.accept(context);
+        if (isUpdateOnClick()) context.update();
     }
 
     @Override

--- a/bukkit/src/main/java/me/devnatan/inventoryframework/component/BukkitItemComponentBuilder.java
+++ b/bukkit/src/main/java/me/devnatan/inventoryframework/component/BukkitItemComponentBuilder.java
@@ -193,7 +193,8 @@ public final class BukkitItemComponentBuilder extends DefaultComponentBuilder<Bu
                 updateHandler,
                 clickHandler,
                 watching,
-                isManagedExternally);
+                isManagedExternally,
+                updateOnClick);
     }
 
     @Override

--- a/framework/src/main/java/me/devnatan/inventoryframework/component/DefaultComponentBuilder.java
+++ b/framework/src/main/java/me/devnatan/inventoryframework/component/DefaultComponentBuilder.java
@@ -13,7 +13,7 @@ abstract class DefaultComponentBuilder<S extends ComponentBuilder<S>> implements
 
     protected String referenceKey;
     protected Map<String, Object> data;
-    protected boolean cancelOnClick, closeOnClick;
+    protected boolean cancelOnClick, closeOnClick, updateOnClick;
     protected final Set<State<?>> watching = new LinkedHashSet<>();
     protected boolean isManagedExternally;
 
@@ -39,6 +39,12 @@ abstract class DefaultComponentBuilder<S extends ComponentBuilder<S>> implements
     @Override
     public S closeOnClick() {
         closeOnClick = !closeOnClick;
+        return (S) this;
+    }
+
+    @Override
+    public S updateOnClick() {
+        updateOnClick = !updateOnClick;
         return (S) this;
     }
 


### PR DESCRIPTION
Creates a shortcut to `onClick(IFContext::update)` by using `item.updateOnClick()`. This is especially to not break the beautified method chaining flow.

**Before**
```java
item.onClick(click -> {
    doSomething();
    click.update();
});
```

**After**
```java
item.updateOnClick().onClick(this::doSomething)
```