### PR TITLE
Trigger update when `updateOnClick` is true and `clickHandler` is null

### DIFF
--- a/api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
+++ b/api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
@@ -171,8 +171,7 @@ public class ItemComponent implements Component, InteractionHandler {
 
     @Override
     public void clicked(@NotNull Component component, @NotNull IFSlotClickContext context) {
-        if (clickHandler == null) return;
-        clickHandler.accept(context);
+        if (clickHandler != null) clickHandler.accept(context);
         if (isUpdateOnClick()) context.update();
     }
 


### PR DESCRIPTION
Fixes usage of `updateOnClick` without `onClick` implemented in #418