### PR TITLE
Detect components overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 3.0.0-rc.3 (unreleased)
+
+* Overlapping components support (#433)
+
 # 3.0.0-rc.2 (08-15-2023)
 
 * New `openForPlayer()` and `openForEveryone()` with initial data parameter like in ViewFrame (#421)

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Component.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Component.java
@@ -38,21 +38,19 @@ public interface Component extends VirtualView {
     boolean isContainedWithin(int position);
 
     /**
+     * If this component are intersects with other component.
+     *
+     * @param other The other component.
+     * @return If both this and other component intersects in area.
+     */
+    boolean intersects(@NotNull Component other);
+
+    /**
      * The interaction handler for this component.
      *
      * @return The interaction handler for this component.
      */
     InteractionHandler getInteractionHandler();
-
-    /**
-     * Determines if this component should be updated.
-     * <p>
-     * This is a simple precondition to make checking the need for component updates more efficient,
-     * checking your own conditions before going to more complex methods.
-     *
-     * @return {@code true} if this component should be updated or {@code false} otherwise.
-     */
-    boolean shouldBeUpdated();
 
     /**
      * Renders this component to the given context.
@@ -108,4 +106,24 @@ public interface Component extends VirtualView {
      */
     @ApiStatus.Internal
     boolean isManagedExternally();
+
+    // TODO Needs documentation
+    boolean shouldRender();
+
+    /**
+     * Checks if two components area intersects with each other.
+     *
+     * @param component The component A.
+     * @param other     The component B.
+     * @return If component B area conflicts with area of component A.
+     */
+    static boolean intersects(@NotNull Component component, @NotNull Component other) {
+        if (other instanceof ComponentComposition) {
+            for (final Component otherChildren : (ComponentComposition) other) {
+                if (otherChildren.intersects(component)) return true;
+            }
+        }
+
+        return other.isContainedWithin(component.getPosition());
+    }
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Component.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Component.java
@@ -92,6 +92,17 @@ public interface Component extends VirtualView {
     boolean isVisible();
 
     /**
+     * Sets the visibility state of this component.
+     * <p>
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     *
+     * @param visible If this component is visible.
+     */
+    @ApiStatus.Internal
+    void setVisible(boolean visible);
+
+    /**
      * <p><b><i>This is an internal inventory-framework API that should not be used from outside of
      * this library. No compatibility guarantees are provided.</i></b>
      */

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ComponentBuilder.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ComponentBuilder.java
@@ -1,5 +1,6 @@
 package me.devnatan.inventoryframework.component;
 
+import java.util.function.BooleanSupplier;
 import me.devnatan.inventoryframework.state.State;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -107,4 +108,12 @@ public interface ComponentBuilder<S extends ComponentBuilder<S>> {
      */
     @ApiStatus.Experimental
     S updateOnClick();
+
+    /**
+     * Only shows the component if a given condition is satisfied.
+     *
+     * @param displayCondition Component display condition.
+     * @return This component builder.
+     */
+    S displayIf(BooleanSupplier displayCondition);
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
@@ -30,6 +30,7 @@ public class ItemComponent implements Component, InteractionHandler {
     private final Set<State<?>> watching;
     private final boolean isManagedExternally;
     private final boolean updateOnClick;
+    private boolean isVisible;
 
     public ItemComponent(
             VirtualView root,
@@ -43,7 +44,8 @@ public class ItemComponent implements Component, InteractionHandler {
             Consumer<? super IFSlotClickContext> clickHandler,
             Set<State<?>> watching,
             boolean isManagedExternally,
-            boolean updateOnClick) {
+            boolean updateOnClick,
+            boolean isVisible) {
         this.root = root;
         this.position = position;
         this.stack = stack;
@@ -56,6 +58,7 @@ public class ItemComponent implements Component, InteractionHandler {
         this.watching = watching;
         this.isManagedExternally = isManagedExternally;
         this.updateOnClick = updateOnClick;
+        this.isVisible = isVisible;
     }
 
     @NotNull
@@ -119,6 +122,7 @@ public class ItemComponent implements Component, InteractionHandler {
     public void render(@NotNull IFSlotRenderContext context) {
         if (getShouldRender() != null && !getShouldRender().getAsBoolean()) {
             context.getContainer().removeItem(getPosition());
+            setVisible(false);
             return;
         }
 
@@ -139,10 +143,12 @@ public class ItemComponent implements Component, InteractionHandler {
                 // TODO Misplaced - move this to overall item component misplacement check
                 if (initialSlot != -1 && initialSlot != updatedSlot) {
                     context.getContainer().removeItem(initialSlot);
+                    setVisible(false);
                 }
             }
 
             context.getContainer().renderItem(getPosition(), context.getResult());
+            setVisible(true);
             return;
         }
 
@@ -151,6 +157,7 @@ public class ItemComponent implements Component, InteractionHandler {
         }
 
         context.getContainer().renderItem(getPosition(), getStack());
+        setVisible(true);
     }
 
     @Override
@@ -168,6 +175,7 @@ public class ItemComponent implements Component, InteractionHandler {
     @Override
     public void clear(@NotNull IFContext context) {
         context.getContainer().removeItem(getPosition());
+        setVisible(false);
     }
 
     @Override
@@ -189,7 +197,12 @@ public class ItemComponent implements Component, InteractionHandler {
 
     @Override
     public boolean isVisible() {
-        return ((IFContext) getRoot()).getContainer().hasItem(getPosition());
+        return isVisible;
+    }
+
+    @Override
+    public void setVisible(boolean visible) {
+        isVisible = visible;
     }
 
     @Override

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFContext.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFContext.java
@@ -207,12 +207,23 @@ public interface IFContext extends VirtualView, StateValueHost {
     void removeComponent(@NotNull Component component);
 
     /**
-     * Updates a single component in this context.
+     * Renders a component in this context.
      *
      * <p><b><i>This is an internal inventory-framework API that should not be used from outside of
      * this library. No compatibility guarantees are provided.</i></b>
      *
-     * @param component To component to be updated.
+     * @param component The component to be rendered.
+     */
+    @ApiStatus.Internal
+    void renderComponent(@NotNull Component component);
+
+    /**
+     * Updates a component in this context.
+     *
+     * <p><b><i>This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided.</i></b>
+     *
+     * @param component The component to be updated.
      */
     @ApiStatus.Internal
     void updateComponent(@NotNull Component component);

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/DefaultComponentBuilder.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/DefaultComponentBuilder.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
 import me.devnatan.inventoryframework.state.State;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,8 +15,28 @@ abstract class DefaultComponentBuilder<S extends ComponentBuilder<S>> implements
     protected String referenceKey;
     protected Map<String, Object> data;
     protected boolean cancelOnClick, closeOnClick, updateOnClick;
-    protected final Set<State<?>> watching = new LinkedHashSet<>();
+    protected Set<State<?>> watchingStates;
     protected boolean isManagedExternally;
+    protected BooleanSupplier displayCondition;
+
+    protected DefaultComponentBuilder(
+            String referenceKey,
+            Map<String, Object> data,
+            boolean cancelOnClick,
+            boolean closeOnClick,
+            boolean updateOnClick,
+            Set<State<?>> watchingStates,
+            boolean isManagedExternally,
+            BooleanSupplier displayCondition) {
+        this.referenceKey = referenceKey;
+        this.data = data;
+        this.cancelOnClick = cancelOnClick;
+        this.closeOnClick = closeOnClick;
+        this.updateOnClick = updateOnClick;
+        this.watchingStates = watchingStates;
+        this.isManagedExternally = isManagedExternally;
+        this.displayCondition = displayCondition;
+    }
 
     @Override
     public S referencedBy(@NotNull String key) {
@@ -50,13 +71,20 @@ abstract class DefaultComponentBuilder<S extends ComponentBuilder<S>> implements
 
     @Override
     public S watch(State<?>... states) {
-        watching.addAll(Arrays.asList(states));
+        if (watchingStates == null) watchingStates = new LinkedHashSet<>();
+        watchingStates.addAll(Arrays.asList(states));
         return (S) this;
     }
 
     @Override
     public S withExternallyManaged(boolean isExternallyManaged) {
         isManagedExternally = isExternallyManaged;
+        return (S) this;
+    }
+
+    @Override
+    public S displayIf(BooleanSupplier displayCondition) {
+        this.displayCondition = displayCondition;
         return (S) this;
     }
 }

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -545,10 +545,19 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
 
     @Override
     public boolean isVisible() {
-        return !getComponentsInternal().isEmpty();
+		for (final Component children : this) {
+			if (!children.isVisible()) return false;
+		}
+
+        return true;
     }
 
-    @Override
+	@Override
+	public void setVisible(boolean visible) {
+		getComponentsInternal().forEach(component -> component.setVisible(visible));
+	}
+
+	@Override
     public void clicked(@NotNull Component component, @NotNull IFSlotClickContext context) {
         final List<Component> components = getComponentsInternal();
         if (components.isEmpty()) return;

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -388,11 +388,6 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
     }
 
     @Override
-    public boolean shouldBeUpdated() {
-        return pageWasChanged;
-    }
-
-    @Override
     public void clear(@NotNull IFContext context) {
         // Only clear components if page was changed to not make the clear operation inconsistent
         if (!pageWasChanged) {
@@ -434,6 +429,11 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
             if (component.isContainedWithin(position)) return true;
         }
         return false;
+    }
+
+    @Override
+    public boolean intersects(@NotNull Component other) {
+        return Component.intersects(this, other);
     }
 
     @Override
@@ -545,19 +545,19 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
 
     @Override
     public boolean isVisible() {
-		for (final Component children : this) {
-			if (!children.isVisible()) return false;
-		}
+        for (final Component children : this) {
+            if (!children.isVisible()) return false;
+        }
 
         return true;
     }
 
-	@Override
-	public void setVisible(boolean visible) {
-		getComponentsInternal().forEach(component -> component.setVisible(visible));
-	}
+    @Override
+    public void setVisible(boolean visible) {
+        getComponentsInternal().forEach(component -> component.setVisible(visible));
+    }
 
-	@Override
+    @Override
     public void clicked(@NotNull Component component, @NotNull IFSlotClickContext context) {
         final List<Component> components = getComponentsInternal();
         if (components.isEmpty()) return;
@@ -580,6 +580,11 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
 
     @Override
     public boolean isManagedExternally() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldRender() {
         return true;
     }
 

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/FirstRenderInterceptor.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/FirstRenderInterceptor.java
@@ -1,15 +1,11 @@
 package me.devnatan.inventoryframework.pipeline;
 
 import java.util.List;
-import java.util.Map;
-import me.devnatan.inventoryframework.Viewer;
 import me.devnatan.inventoryframework.VirtualView;
 import me.devnatan.inventoryframework.component.Component;
 import me.devnatan.inventoryframework.component.ComponentFactory;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.context.IFRenderContext;
-import me.devnatan.inventoryframework.context.IFSlotRenderContext;
-import me.devnatan.inventoryframework.internal.ElementFactory;
 import me.devnatan.inventoryframework.state.State;
 import me.devnatan.inventoryframework.state.StateValue;
 import me.devnatan.inventoryframework.state.StateValueHost;
@@ -27,35 +23,26 @@ public final class FirstRenderInterceptor implements PipelineInterceptor<Virtual
 
         final IFRenderContext context = (IFRenderContext) subject;
         registerComponents(context);
-
-        final Map<String, Viewer> viewers = context.getIndexedViewers();
-        final ElementFactory elementFactory = context.getRoot().getElementFactory();
         final List<Component> componentList = context.getComponents();
 
         for (int i = componentList.size(); i > 0; i--) {
             final Component component = componentList.get(i - 1);
-            final IFSlotRenderContext slotRenderContext = elementFactory.createSlotContext(
-                    component.getPosition(),
-                    component,
-                    context.getContainer(),
-                    context.getViewer(),
-                    viewers,
-                    context,
-                    IFSlotRenderContext.class);
-
-            setupWatchers(context, component);
-            component.render(slotRenderContext);
+            context.renderComponent(component);
         }
     }
 
     /**
-     * Registers all components set up from {@link IFRenderContext#getComponentFactories()} to
-     * the renderization context.
+     * Registers all components set up from {@link IFRenderContext#getComponentFactories() component factories}
+     * to the rendering context.
      *
      * @param context The context.
      */
     private void registerComponents(IFRenderContext context) {
-        context.getComponentFactories().stream().map(ComponentFactory::create).forEach(context::addComponent);
+        context.getComponentFactories().stream()
+                .map(ComponentFactory::create)
+                // TODO Setup watches on context initialization not on first render
+                .peek(component -> setupWatchers(context, component))
+                .forEach(context::addComponent);
     }
 
     /**

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/component/BukkitItemComponentBuilder.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/component/BukkitItemComponentBuilder.java
@@ -205,7 +205,8 @@ public final class BukkitItemComponentBuilder extends DefaultComponentBuilder<Bu
                 clickHandler,
                 watchingStates,
                 isManagedExternally,
-                updateOnClick);
+                updateOnClick,
+                false);
     }
 
     @Override

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/SlotContext.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/SlotContext.java
@@ -156,6 +156,11 @@ public class SlotContext extends ConfinedContext implements IFSlotContext, Conte
     }
 
     @Override
+    public void renderComponent(@NotNull Component component) {
+        throw new UnsupportedOperationException("Slot context do not have components");
+    }
+
+    @Override
     public void updateComponent(@NotNull Component component) {
         throw new UnsupportedOperationException("Slot context do not have components");
     }

--- a/inventory-framework-platform/src/test/java/me/devnatan/inventoryframework/component/TestItemComponentBuilder.java
+++ b/inventory-framework-platform/src/test/java/me/devnatan/inventoryframework/component/TestItemComponentBuilder.java
@@ -11,6 +11,10 @@ public class TestItemComponentBuilder extends DefaultComponentBuilder<TestItemCo
 
     int slot;
 
+    public TestItemComponentBuilder() {
+        this(null, null, false, false, false, null, false, null);
+    }
+
     protected TestItemComponentBuilder(
             String referenceKey,
             Map<String, Object> data,

--- a/inventory-framework-platform/src/test/java/me/devnatan/inventoryframework/component/TestItemComponentBuilder.java
+++ b/inventory-framework-platform/src/test/java/me/devnatan/inventoryframework/component/TestItemComponentBuilder.java
@@ -1,5 +1,8 @@
 package me.devnatan.inventoryframework.component;
 
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
 import me.devnatan.inventoryframework.state.State;
 import org.jetbrains.annotations.NotNull;
 
@@ -7,6 +10,26 @@ public class TestItemComponentBuilder extends DefaultComponentBuilder<TestItemCo
         implements ItemComponentBuilder<TestItemComponentBuilder>, ComponentFactory {
 
     int slot;
+
+    protected TestItemComponentBuilder(
+            String referenceKey,
+            Map<String, Object> data,
+            boolean cancelOnClick,
+            boolean closeOnClick,
+            boolean updateOnClick,
+            Set<State<?>> watchingStates,
+            boolean isManagedExternally,
+            BooleanSupplier displayCondition) {
+        super(
+                referenceKey,
+                data,
+                cancelOnClick,
+                closeOnClick,
+                updateOnClick,
+                watchingStates,
+                isManagedExternally,
+                displayCondition);
+    }
 
     @Override
     public @NotNull Component create() {

--- a/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
+++ b/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
@@ -40,7 +40,12 @@ public class FakeComponent implements Component, InteractionHandler {
         return this.position == position;
     }
 
-    @Override
+	@Override
+	public boolean intersects(@NotNull Component other) {
+		return false;
+	}
+
+	@Override
     public @NotNull InteractionHandler getInteractionHandler() {
         return this;
     }
@@ -52,11 +57,6 @@ public class FakeComponent implements Component, InteractionHandler {
 
     @Override
     public void updated(@NotNull IFSlotRenderContext context) {}
-
-    @Override
-    public boolean shouldBeUpdated() {
-        throw new UnsupportedOperationException("Not implemented");
-    }
 
     @Override
     public void clear(@NotNull IFContext context) {
@@ -73,11 +73,21 @@ public class FakeComponent implements Component, InteractionHandler {
         return true;
     }
 
-    @Override
+	@Override
+	public void setVisible(boolean visible) {
+
+	}
+
+	@Override
     public boolean isManagedExternally() {
         return false;
     }
 
-    @Override
+	@Override
+	public boolean shouldRender() {
+		return false;
+	}
+
+	@Override
     public void clicked(@NotNull Component component, @NotNull IFSlotClickContext context) {}
 }

--- a/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
+++ b/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
@@ -40,12 +40,12 @@ public class FakeComponent implements Component, InteractionHandler {
         return this.position == position;
     }
 
-	@Override
-	public boolean intersects(@NotNull Component other) {
-		return false;
-	}
+    @Override
+    public boolean intersects(@NotNull Component other) {
+        return false;
+    }
 
-	@Override
+    @Override
     public @NotNull InteractionHandler getInteractionHandler() {
         return this;
     }
@@ -73,21 +73,19 @@ public class FakeComponent implements Component, InteractionHandler {
         return true;
     }
 
-	@Override
-	public void setVisible(boolean visible) {
+    @Override
+    public void setVisible(boolean visible) {}
 
-	}
-
-	@Override
+    @Override
     public boolean isManagedExternally() {
         return false;
     }
 
-	@Override
-	public boolean shouldRender() {
-		return false;
-	}
+    @Override
+    public boolean shouldRender() {
+        return false;
+    }
 
-	@Override
+    @Override
     public void clicked(@NotNull Component component, @NotNull IFSlotClickContext context) {}
 }


### PR DESCRIPTION
Fixes #428

Before this PR the code below do not work very well.
What we expect is: `showIronState` is true? Show IRON_INGOT. Iron item visibility is based on `displayIf` but currently the GOLD_INGOT is always shown if it's declaration comes first or if it comes later, the iron item is shown and when `displayIf` becomes false - nothing is displayed at all the slot becames empty.

```java
MutableState<Boolean> showIronState = mutableState(false);

render.firstSlot(new ItemStack(Material.IRON_INGOT)).displayIf(() -> showIronState.get(context))

// ... an item to update `showIronState` state somehow ...

render.firstSlot(new ItemStack(Material.GOLD_INGOT));
```

We do not need a `watch(showIronState)` in IRON_INGOT item because `displayIf` reacts to any global update so `context.update()` works. 

That doesn't apply to things like Pagination because Pagination is a specific component so when a pagination updates it triggers update internally only in the pagination component itself so a `watch(paginationState)` will be needed.