### PR TITLE
Allow get current slot in `layoutSlot` factory

### DIFF
--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/internal/LayoutSlot.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/internal/LayoutSlot.java
@@ -2,20 +2,28 @@ package me.devnatan.inventoryframework.internal;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.IntFunction;
 import me.devnatan.inventoryframework.component.ComponentFactory;
+import me.devnatan.inventoryframework.jdk.IndexSlotFunction;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * <b><i> This is an internal inventory-framework API that should not be used from outside of
+ * this library. No compatibility guarantees are provided. </i></b>
+ */
+@ApiStatus.Internal
 public final class LayoutSlot {
 
     // Retro compatibility
     public static final char FILLED_RESERVED_CHAR = 'O';
 
     private final char character;
-    private final IntFunction<ComponentFactory> factory;
+    private final IndexSlotFunction<ComponentFactory> factory;
     private final int[] positions;
 
-    public LayoutSlot(char character, @Nullable IntFunction<ComponentFactory> factory, int[] positions) {
+    public LayoutSlot(char character, @Nullable IndexSlotFunction<ComponentFactory> factory, int[] positions) {
         this.character = character;
         this.factory = factory;
         this.positions = positions;
@@ -25,11 +33,11 @@ public final class LayoutSlot {
         return character;
     }
 
-    public IntFunction<ComponentFactory> getFactory() {
+    public IndexSlotFunction<ComponentFactory> getFactory() {
         return factory;
     }
 
-    public LayoutSlot withFactory(@Nullable IntFunction<ComponentFactory> factory) {
+    public LayoutSlot withFactory(@Nullable IndexSlotFunction<ComponentFactory> factory) {
         return new LayoutSlot(character, factory, positions);
     }
 

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/jdk/IndexSlotConsumer.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/jdk/IndexSlotConsumer.java
@@ -1,0 +1,20 @@
+package me.devnatan.inventoryframework.jdk;
+
+/**
+ * Represents an operation that accepts an iteration index as first argument, an int-valued slot position as second argument
+ * and an object-valued input as third argument, and returns no result.
+ *
+ * @param <T> The type of the object argument to the operation.
+ */
+@FunctionalInterface
+public interface IndexSlotConsumer<T> {
+
+    /**
+     * Performs this operation on the given arguments.
+     *
+     * @param index The iteration index.
+     * @param slot  The slot position.
+     * @param value The input argument.
+     */
+    void accept(int index, int slot, T value);
+}

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/jdk/IndexSlotFunction.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/jdk/IndexSlotFunction.java
@@ -1,0 +1,20 @@
+package me.devnatan.inventoryframework.jdk;
+
+/**
+ * Represents a function that accepts and int-valued iteration index as first argument
+ * and a int-valued slot position as second argument and produces a result.
+ *
+ * @param <R> The type of the result of the function.
+ */
+@FunctionalInterface
+public interface IndexSlotFunction<R> {
+
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param index The iteration index.
+     * @param slot  The slot position.
+     * @return The function result.
+     */
+    R apply(int index, int slot);
+}


### PR DESCRIPTION
Now is possible to use `getSlot` inside `layoutSlot` factory also added some missing documentations and created Function-like interfaces to simplify usage