### PR TITLE
Add component to render context without restrictions

### DIFF
--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFRenderContext.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFRenderContext.java
@@ -49,5 +49,5 @@ public interface IFRenderContext extends IFConfinedContext {
      * @param component The component.
      */
     @ApiStatus.Experimental
-    void component(@NotNull Component component);
+    void addComponent(@NotNull Component component);
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFRenderContext.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFRenderContext.java
@@ -2,6 +2,7 @@ package me.devnatan.inventoryframework.context;
 
 import java.util.List;
 import java.util.function.BiFunction;
+import me.devnatan.inventoryframework.component.Component;
 import me.devnatan.inventoryframework.component.ComponentFactory;
 import me.devnatan.inventoryframework.internal.LayoutSlot;
 import org.jetbrains.annotations.ApiStatus;
@@ -38,4 +39,15 @@ public interface IFRenderContext extends IFConfinedContext {
      */
     @ApiStatus.Internal
     BiFunction<Integer, Integer, ComponentFactory> getAvailableSlotFactory();
+
+    /**
+     * Adds a new component to this context, without restrictions.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param component The component.
+     */
+    @ApiStatus.Experimental
+    void component(@NotNull Component component);
 }

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/context/BaseViewContext.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/context/BaseViewContext.java
@@ -29,7 +29,7 @@ class BaseViewContext extends DefaultStateValueHost implements IFContext {
     private final @NotNull RootView root;
     // Container can be null on pre-render/intermediate contexts
     private final @Nullable ViewContainer container;
-    private final List<Component> components = new LinkedList<>();
+    final List<Component> components = new LinkedList<>();
     private final Deque<Integer> markedForRemoval = new ArrayDeque<>();
     private final Object initialData;
     protected final Map<String, Viewer> viewers;

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformRenderContext.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformRenderContext.java
@@ -11,6 +11,7 @@ import me.devnatan.inventoryframework.RootView;
 import me.devnatan.inventoryframework.ViewConfig;
 import me.devnatan.inventoryframework.ViewContainer;
 import me.devnatan.inventoryframework.Viewer;
+import me.devnatan.inventoryframework.component.Component;
 import me.devnatan.inventoryframework.component.ComponentFactory;
 import me.devnatan.inventoryframework.component.ItemComponentBuilder;
 import me.devnatan.inventoryframework.internal.LayoutSlot;
@@ -68,6 +69,13 @@ abstract class PlatformRenderContext<T extends ItemComponentBuilder<T, C>, C ext
     @Override
     public BiFunction<Integer, Integer, ComponentFactory> getAvailableSlotFactory() {
         return availableSlotFactory;
+    }
+
+    @Override
+    public void component(@NotNull Component component) {
+        synchronized (components) {
+            components.add(component);
+        }
     }
 
     /**

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformRenderContext.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformRenderContext.java
@@ -72,7 +72,7 @@ abstract class PlatformRenderContext<T extends ItemComponentBuilder<T, C>, C ext
     }
 
     @Override
-    public void component(@NotNull Component component) {
+    public void addComponent(@NotNull Component component) {
         synchronized (components) {
             components.add(component);
         }


### PR DESCRIPTION
Component API will be more dev friendly in v3.0.0-rc.3+, changes are needed for further built-in components

Example
```java
// Built-in head component
class Head extends ItemComponent { ... }
```
```java
@Override
public void onFirstRender(RenderContext context) {
   // renders the head component in the first slot
   context.firstSlot(new Head("DevNatan"));

   // or (components can manage its own position so just this can be used)
   context.component(new Head("DevNatan"));
}
```

Builders must be supported as well

```java
class HeadBuilder implements ComponentBuilder {

    HeadBuilder playerName(String playerName) { ... }
}
```

Renders HeadBuilder component result in the '#' layout character
```java
@Override
public void onFirstRender(RenderContext context) {
    context.layoutSlot('#', new HeadBuilder()).playerName("Natan");
}
```

Maybe remove the usage of `new` by using Component class and implicit builder
```java
@Override
public void onFirstRender(RenderContext context) {
    context.layoutSlot('#', HeadComponent.class).playerName("Natan");
}
```