### PR TITLE
Fix lazy pagination reloading

### DIFF
--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Component.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Component.java
@@ -111,6 +111,11 @@ public interface Component extends VirtualView {
     boolean shouldRender(IFContext context);
 
     /**
+     * Updates this component.
+     */
+    void update();
+
+    /**
      * Checks if two components area intersects with each other.
      *
      * @param component The component A.

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
@@ -192,8 +192,7 @@ public class ItemComponent implements Component, InteractionHandler {
 
     @Override
     public boolean isVisible() {
-		if (root instanceof Component)
-			return ((Component) root).isVisible() && isVisible;
+        if (root instanceof Component) return ((Component) root).isVisible() && isVisible;
 
         return isVisible;
     }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
@@ -176,7 +176,6 @@ public class ItemComponent implements Component, InteractionHandler {
     @Override
     public void clear(@NotNull IFContext context) {
         ((IFRenderContext) context).getContainer().removeItem(getPosition());
-
         setVisible(false);
     }
 

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
@@ -192,6 +192,9 @@ public class ItemComponent implements Component, InteractionHandler {
 
     @Override
     public boolean isVisible() {
+		if (root instanceof Component)
+			return ((Component) root).isVisible() && isVisible;
+
         return isVisible;
     }
 

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
@@ -179,6 +179,15 @@ public class ItemComponent implements Component, InteractionHandler {
     }
 
     @Override
+    public void update() {
+        if (isManagedExternally())
+            throw new IllegalStateException(
+                    "This component is externally managed by another component and cannot be updated directly");
+
+        if (root instanceof IFContext) ((IFContext) root).updateComponent(this);
+    }
+
+    @Override
     public @UnmodifiableView Set<State<?>> getWatchingStates() {
         return Collections.unmodifiableSet(getWatching());
     }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
@@ -176,7 +176,6 @@ public class ItemComponent implements Component, InteractionHandler {
     @Override
     public void clear(@NotNull IFContext context) {
         ((IFRenderContext) context).getContainer().removeItem(getPosition());
-        setVisible(false);
     }
 
     @Override

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Pagination.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Pagination.java
@@ -135,6 +135,13 @@ public interface Pagination extends ComponentComposition, StateValue {
     boolean isLazy();
 
     /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    boolean isStatic();
+
+    /**
      * If the pagination data is being loaded or not.
      * <p>
      * Only changes if {@link #isLazy()} is true.

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Pagination.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Pagination.java
@@ -132,12 +132,12 @@ public interface Pagination extends ComponentComposition, StateValue {
      * this library. No compatibility guarantees are provided. </i></b>
      */
     @ApiStatus.Internal
-    boolean isDynamic();
+    boolean isLazy();
 
     /**
      * If the pagination data is being loaded or not.
      * <p>
-     * Only changes if {@link #isDynamic()} is true.
+     * Only changes if {@link #isLazy()} is true.
      *
      * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
      * such API may be changed or may be removed completely in any further release. </i></b>

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Pagination.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Pagination.java
@@ -1,5 +1,9 @@
 package me.devnatan.inventoryframework.component;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import me.devnatan.inventoryframework.state.StateValue;
 import me.devnatan.inventoryframework.state.StateValueHost;
 import org.jetbrains.annotations.ApiStatus;
@@ -151,4 +155,33 @@ public interface Pagination extends ComponentComposition, StateValue {
      */
     @ApiStatus.Experimental
     boolean isLoading();
+
+    /**
+     * Gets all elements in a given page index based of the specified source.
+     *
+     * @param index The page index.
+     * @param pageSize Number of elements that each page can have.
+     * @param pagesCount Pre-calculated total number of pages available (set zero if not available).
+     * @param src   The source to split.
+     * @return All elements in a page.
+     * @throws IndexOutOfBoundsException If the specified index is {@code < 0} or
+     *                                   exceeds the pages count.
+     */
+    static List<?> splitSourceForPage(int index, int pageSize, int pagesCount, List<?> src) {
+        if (src.isEmpty()) return Collections.emptyList();
+
+        if (src.size() <= pageSize) return new ArrayList<>(src);
+        if (index < 0 || (pagesCount > 0 && index > pagesCount))
+            throw new IndexOutOfBoundsException(String.format(
+                    "Page index must be between the range of 0 and %d. Given: %d", pagesCount - 1, index));
+
+        final List<Object> contents = new LinkedList<>();
+        final int base = index * pageSize;
+        int until = base + pageSize;
+        if (until > src.size()) until = src.size();
+
+        for (int i = base; i < until; i++) contents.add(src.get(i));
+
+        return contents;
+    }
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Pagination.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Pagination.java
@@ -132,6 +132,14 @@ public interface Pagination extends ComponentComposition, StateValue {
     char getLayoutTarget();
 
     /**
+     * Lazy pagination usually have a Function or Supplier as source provider and this provider
+     * is only called again to set the current internal source when an explicit update is called.
+     * <p>
+     * So, when this method returns <code>true</code> the only way to update the current source as a
+     * whole is triggering an update somehow e.g. by calling {@link #update()}.
+     * <p>
+     * Page switches will not trigger the source provider to re-apply the current internal source.
+     * <p>
      * <b><i> This is an internal inventory-framework API that should not be used from outside of
      * this library. No compatibility guarantees are provided. </i></b>
      */
@@ -139,6 +147,10 @@ public interface Pagination extends ComponentComposition, StateValue {
     boolean isLazy();
 
     /**
+     * Static pagination usually have a Collection or something else as source provider and this
+	 * source provider is called only on first render to set the current source as a whole,
+	 * and never called again on the entire Pagination lifecycle.
+     * <p>
      * <b><i> This is an internal inventory-framework API that should not be used from outside of
      * this library. No compatibility guarantees are provided. </i></b>
      */

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Pagination.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Pagination.java
@@ -132,8 +132,11 @@ public interface Pagination extends ComponentComposition, StateValue {
     char getLayoutTarget();
 
     /**
-     * Lazy pagination usually have a Function or Supplier as source provider and this provider
-     * is only called again to set the current internal source when an explicit update is called.
+     * Lazy pagination usually have a {@link java.util.function.Function} as source provider and
+     * this provider is only called  again to set the current internal source when an explicit
+     * update is called. This kind of pagination is used to replicate a static-like pagination since
+     * it can use a Function to provide some information to composite the source that'll be built
+     * but will never change again.
      * <p>
      * So, when this method returns <code>true</code> the only way to update the current source as a
      * whole is triggering an update somehow e.g. by calling {@link #update()}.
@@ -147,9 +150,9 @@ public interface Pagination extends ComponentComposition, StateValue {
     boolean isLazy();
 
     /**
-     * Static pagination usually have a Collection or something else as source provider and this
-	 * source provider is called only on first render to set the current source as a whole,
-	 * and never called again on the entire Pagination lifecycle.
+     * Static pagination is a type of pagination that usually have a {@link java.util.Collection} or
+     * something else as source provider and this source provider is called only on first render to
+     * set the current source as a whole, and never called again on the entire Pagination lifecycle.
      * <p>
      * <b><i> This is an internal inventory-framework API that should not be used from outside of
      * this library. No compatibility guarantees are provided. </i></b>
@@ -158,12 +161,44 @@ public interface Pagination extends ComponentComposition, StateValue {
     boolean isStatic();
 
     /**
-     * If the pagination data is being loaded or not.
+     * Computed pagination usually have a {@link java.util.function.Function}-like as source provider
+     * and this provider is called each time this component is updated or the page is changed so the
+     * current as a whole will always be the result of the source provider, regardless the {@link #currentPage() current page}.
      * <p>
-     * Only changes if {@link #isLazy()} is true.
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    boolean isComputed();
+
+    /**
+     * Asynchronous pagination can have a mix of all others {@link #isStatic() static}, {@link #isLazy() lazy} and {@link #isComputed() computed}
+     * types of pagination source, that is:
+     * <ul>
+     *     <li>Have a CompletableFuture as source? Then it's static.</li>
+     *     <li>Have a Function or Supplier as source? Type will be defined by implementation.</li>
+     * </ul>
+     * <p>
+     * {@link java.util.concurrent.CompletableFuture} is the type of the source provider or something
+     * that results in a CompletableFuture. Pagination source type is defined by the implementation.
+     * <p>
+     * Internally asynchronous pagination also have a {@link #isLoading() loading state} that
+     * tracks the loading state of the future and changes based on future completion.
+     * <p>
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    boolean isAsync();
+
+    /**
+     * If the pagination data is being loaded.
      *
      * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
      * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @return Loading state of the pagination.
+     * Always <code>false</code> when {@link #isStatic()} is <code>true</code>.
      */
     @ApiStatus.Experimental
     boolean isLoading();

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/PaginationValueConsumer.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/PaginationValueConsumer.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
  * @param <V> The value that represents the current element being paginated
  */
 @FunctionalInterface
-public interface PaginationElementConsumer<Context, Builder, V> {
+public interface PaginationValueConsumer<Context, Builder, V> {
 
     /**
      * Performs this operation on the given arguments.

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/PaginationValueConsumer.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/PaginationValueConsumer.java
@@ -3,14 +3,16 @@ package me.devnatan.inventoryframework.component;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Represents an pagination element mapping operation that accepts three arguments and returns no result.
+ * Represents a pagination element mapping operation that accepts three arguments and returns no result.
+ * <p>
  * This is a {@link FunctionalInterface functional interface} whose functional method is {@link #accept(Object, Object, int, Object)}.
- * @param <Context> The type of the pagination context
- * @param <Builder> The builder used to build the paginated element
+ *
+ * @param <C> The type of the pagination context
+ * @param <B> The builder used to build the paginated element
  * @param <V> The value that represents the current element being paginated
  */
 @FunctionalInterface
-public interface PaginationValueConsumer<Context, Builder, V> {
+public interface PaginationValueConsumer<C, B, V> {
 
     /**
      * Performs this operation on the given arguments.
@@ -20,5 +22,5 @@ public interface PaginationValueConsumer<Context, Builder, V> {
      * @param index The index of the element being paginated in the pagination
      * @param value The value that represents the current element being paginated
      */
-    void accept(@NotNull Context context, @NotNull Builder builder, int index, @NotNull V value);
+    void accept(@NotNull C context, @NotNull B builder, int index, @NotNull V value);
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFContext.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFContext.java
@@ -168,18 +168,6 @@ public interface IFContext extends VirtualView, StateValueHost {
     void update();
 
     /**
-     * Checks if a component positioned in a given index is marked for removal.
-     * <p>
-     * <b><i> This is an internal inventory-framework API that should not be used from outside of
-     * this library. No compatibility guarantees are provided. </i></b>
-     *
-     * @param componentIndex The index of the component to be checked if it's marked for removal.
-     * @return If the component in the specified index (if any) is marked for removal.
-     */
-    @ApiStatus.Internal
-    boolean isMarkedForRemoval(int componentIndex);
-
-    /**
      * Data defined when a context is created, usually this is data set when the context is
      * opened for a viewer.
      *

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFRenderContext.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFRenderContext.java
@@ -54,4 +54,11 @@ public interface IFRenderContext extends IFConfinedContext {
      */
     @NotNull
     ViewContainer getContainer();
+
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    boolean isRendered();
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFUpdateContext.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFUpdateContext.java
@@ -1,3 +1,0 @@
-package me.devnatan.inventoryframework.context;
-
-public interface IFUpdateContext extends IFContext {}

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -38,7 +38,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
 
     // --- Internal ---
     private int currPageIndex;
-    private final boolean dynamic;
+    private final boolean lazy;
     private boolean pageWasChanged;
     private boolean initialized;
     private int pagesCount;
@@ -78,13 +78,13 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         this.elementFactory = elementFactory;
         this.pageSwitchHandler = pageSwitchHandler;
         this.currSource = convertSourceProvider();
-        this.dynamic = !(sourceProvider instanceof Collection);
+        this.lazy = !(sourceProvider instanceof Collection);
     }
 
     /**
      * Tries to access and load the source to the current page.
      * <p>
-     * If this pagination {@link #isDynamic() is dynamic} it tries to get the current data source
+     * If this pagination {@link #isLazy() is dynamic} it tries to get the current data source
      * dynamically or asynchronously and waits for its completion.
      * <p>
      * For static pagination it returns immediately with the source.
@@ -103,7 +103,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         // must use the current data source as source of truth to ensure that pagination switches do
         // not trigger pagination data factory since it will always return the source as a whole,
         // the original one, and not the source for the switched page.
-        if (!isDynamic() || !initialized) {
+        if (!isLazy() || !initialized) {
             if (initialized && currSource == null)
                 throw new IllegalStateException("User provided pagination source cannot be null");
             if (!initialized) pagesCount = calculatePagesCount(currSource);
@@ -529,8 +529,8 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
     }
 
     @Override
-    public boolean isDynamic() {
-        return dynamic;
+    public boolean isLazy() {
+        return lazy;
     }
 
     @Override
@@ -602,7 +602,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         return getLayoutTarget() == that.getLayoutTarget()
                 && currPageIndex == that.currPageIndex
                 && getPageSize() == that.getPageSize()
-                && isDynamic() == that.isDynamic()
+                && isLazy() == that.isLazy()
                 && pageWasChanged == that.pageWasChanged
                 && Objects.equals(sourceProvider, that.sourceProvider)
                 && Objects.equals(pageSwitchHandler, that.pageSwitchHandler);
@@ -616,7 +616,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
                 pageSwitchHandler,
                 currPageIndex,
                 getPageSize(),
-                isDynamic(),
+                isLazy(),
                 pageWasChanged);
     }
 
@@ -630,7 +630,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
                 + pageSwitchHandler + ", currPageIndex="
                 + currPageIndex + ", pageSize="
                 + pageSize + ", dynamic="
-                + dynamic + ", pageWasChanged="
+                + lazy + ", pageWasChanged="
                 + pageWasChanged + ", _srcFactory="
                 + _srcFactory + ", currSource="
                 + currSource + "} "

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -30,6 +30,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
 
     private final List<Component> components = new LinkedList<>();
     private final IFContext host;
+    private boolean visible;
 
     // --- User provided ---
     private final char layoutTarget;
@@ -44,9 +45,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
     private boolean initialized;
     private int pagesCount;
 
-    /**
-     * The number of elements that each page can have. -1 means uninitialized.
-     */
+    // Number of elements that each page can have. -1 means uninitialized.
     private int pageSize = -1;
 
     // Changes when dynamic data source is used and being loaded
@@ -60,9 +59,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
      */
     private Function<IFContext, Object> _srcFactory;
 
-    /**
-     * Current page source. Only {@code null} before first pagination render.
-     */
+    // Current page source, null before first pagination render.
     private List<?> currSource;
 
     public PaginationImpl(
@@ -553,16 +550,12 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
 
     @Override
     public boolean isVisible() {
-        for (final Component children : this) {
-            if (!children.isVisible()) return false;
-        }
-
-        return true;
+        return visible;
     }
 
     @Override
     public void setVisible(boolean visible) {
-        getComponentsInternal().forEach(component -> component.setVisible(visible));
+        this.visible = visible;
     }
 
     @Override

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -29,12 +29,12 @@ import org.jetbrains.annotations.VisibleForTesting;
 public class PaginationImpl extends AbstractStateValue implements Pagination, InteractionHandler {
 
     private final List<Component> components = new LinkedList<>();
-    private final @NotNull IFContext host;
+    private final IFContext host;
 
     // --- User provided ---
     private final char layoutTarget;
-    private final @NotNull Object sourceProvider;
-    private final @NotNull PaginationElementFactory<IFContext, Object> elementFactory;
+    private final Object sourceProvider;
+    private final PaginationElementFactory<IFContext, Object> elementFactory;
     private final BiConsumer<IFContext, Pagination> pageSwitchHandler;
 
     // --- Internal ---
@@ -66,11 +66,11 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
     private List<?> currSource;
 
     public PaginationImpl(
-            @NotNull State<?> state,
-            @NotNull IFContext host,
+            State<?> state,
+            IFContext host,
             char layoutTarget,
-            @NotNull Object sourceProvider,
-            @NotNull PaginationElementFactory<IFContext, Object> elementFactory,
+            Object sourceProvider,
+            PaginationElementFactory<IFContext, Object> elementFactory,
             BiConsumer<IFContext, Pagination> pageSwitchHandler) {
         super(state);
         this.host = host;

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -342,10 +342,11 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
 
     @Override
     public void updated(@NotNull IFSlotRenderContext context) {
+		final IFRenderContext renderContext = context.getParent();
+
         // If page was changed all components will be removed, so don't trigger update on them
         if (pageWasChanged) {
-            final IFRenderContext renderContext = context.getParent();
-            getComponentsInternal().forEach(child -> child.clear(context));
+            getComponentsInternal().forEach(child -> child.clear(renderContext));
             components = new ArrayList<>();
             getComponentsInternal().clear();
             loadCurrentPage(renderContext).thenRun(() -> {

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -79,7 +79,9 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         this.elementFactory = elementFactory;
         this.pageSwitchHandler = pageSwitchHandler;
         this.currSource = convertSourceProvider();
-        this.isLazy = sourceProvider instanceof Supplier || sourceProvider instanceof BiFunction;
+        this.isLazy = sourceProvider instanceof Supplier
+			|| sourceProvider instanceof Function
+			|| sourceProvider instanceof BiFunction;
         this.isStatic = sourceProvider instanceof Collection;
     }
 

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -376,12 +376,12 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         // If page was changed all components will be removed, so don't trigger update on them
         if (pageWasChanged) {
             final IFRenderContext renderContext = context.getParent();
-            clearChild(renderContext, true);
+			clearChild(renderContext, false);
             loadCurrentPage(renderContext).thenRun(() -> {
                 render(context);
                 simulateStateUpdate();
-                pageWasChanged = false;
             });
+			pageWasChanged = false;
             return;
         }
 
@@ -406,11 +406,11 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
             return;
         }
 
-        clearChild(context, false);
+        clearChild(context, true);
     }
 
-    private void clearChild(IFContext context, boolean bulk) {
-        if (bulk) {
+    private void clearChild(IFContext context, boolean sync) {
+        if (!sync) {
             getComponentsInternal().forEach(child -> child.clear(context));
             getComponentsInternal().clear();
             return;

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -79,7 +79,8 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         this.isComputed = isComputed;
         this.isAsync = isAsync;
         this.isStatic = sourceProvider instanceof Collection || isAsync;
-        this.isLazy = !isStatic && isComputed;
+        this.isLazy =
+                !isStatic && !isComputed && (sourceProvider instanceof Function || sourceProvider instanceof Supplier);
     }
 
     /**

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -324,7 +324,6 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
 
     @Override
     public void render(@NotNull IFSlotRenderContext context) {
-        System.out.println("initialized = " + initialized);
         if (!initialized) {
             setVisible(true);
             final IFRenderContext root = context.getParent();
@@ -538,7 +537,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
     @Override
     public void setVisible(boolean visible) {
         this.visible = visible;
-		getComponentsInternal().forEach(component -> component.setVisible(visible));
+        getComponentsInternal().forEach(component -> component.setVisible(visible));
     }
 
     @Override

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 @VisibleForTesting
 public class PaginationImpl extends AbstractStateValue implements Pagination, InteractionHandler {
 
-    private final List<Component> components = new LinkedList<>();
+    private List<Component> components = new ArrayList<>();
     private final IFContext host;
     private boolean visible;
 
@@ -376,6 +376,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         if (pageWasChanged) {
             final IFRenderContext renderContext = context.getParent();
             getComponentsInternal().forEach(child -> child.clear(context));
+			components = new ArrayList<>();
             getComponentsInternal().clear();
             loadCurrentPage(renderContext).thenRun(() -> {
                 render(context);

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/context/AbstractIFContext.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/context/AbstractIFContext.java
@@ -1,9 +1,7 @@
 package me.devnatan.inventoryframework.context;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -23,7 +21,6 @@ import org.jetbrains.annotations.UnmodifiableView;
 abstract class AbstractIFContext extends DefaultStateValueHost implements IFContext {
 
     private final List<Component> components = new LinkedList<>();
-    private final Deque<Integer> markedForRemoval = new ArrayDeque<>();
     private final Map<String, Viewer> indexedViewers = new HashMap<>();
     protected ViewConfig config;
 
@@ -127,11 +124,6 @@ abstract class AbstractIFContext extends DefaultStateValueHost implements IFCont
     @Override
     public void update() {
         getRoot().getPipeline().execute(StandardPipelinePhases.UPDATE, this);
-    }
-
-    @Override
-    public final boolean isMarkedForRemoval(int componentIndex) {
-        return markedForRemoval.contains(componentIndex);
     }
 
     @Override

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/context/AbstractIFContext.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/context/AbstractIFContext.java
@@ -80,7 +80,7 @@ abstract class AbstractIFContext extends DefaultStateValueHost implements IFCont
         }
     }
 
-    private IFSlotRenderContext createRenderContext(@NotNull Component component) {
+    private IFSlotRenderContext createSlotRenderContext(@NotNull Component component) {
         if (!(this instanceof IFRenderContext))
             throw new InventoryFrameworkException("Slot render context cannot be created from non-render parent");
 
@@ -113,12 +113,12 @@ abstract class AbstractIFContext extends DefaultStateValueHost implements IFCont
             return;
         }
 
-        component.render(createRenderContext(component));
+        component.render(createSlotRenderContext(component));
     }
 
     @Override
     public void updateComponent(@NotNull Component component) {
-        component.updated(createRenderContext(component));
+        component.updated(createSlotRenderContext(component));
     }
 
     @Override

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/UpdateInterceptor.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/UpdateInterceptor.java
@@ -3,7 +3,6 @@ package me.devnatan.inventoryframework.pipeline;
 import java.util.List;
 import me.devnatan.inventoryframework.VirtualView;
 import me.devnatan.inventoryframework.component.Component;
-import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.context.IFRenderContext;
 
 /**
@@ -15,7 +14,9 @@ public final class UpdateInterceptor implements PipelineInterceptor<VirtualView>
     public void intercept(PipelineContext<VirtualView> pipeline, VirtualView subject) {
         if (!(subject instanceof IFRenderContext)) return;
 
-        final IFContext context = (IFContext) subject;
+        final IFRenderContext context = (IFRenderContext) subject;
+        if (!context.isRendered()) return;
+
         final List<Component> componentList = context.getComponents();
         for (final Component component : componentList) {
             if (!component.isVisible()) {

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/UpdateInterceptor.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/UpdateInterceptor.java
@@ -17,9 +17,8 @@ public final class UpdateInterceptor implements PipelineInterceptor<VirtualView>
 
         final IFContext context = (IFContext) subject;
         final List<Component> componentList = context.getComponents();
-        for (int i = 0; i < componentList.size(); i++) {
-            final Component component = componentList.get(i);
-            if (context.isMarkedForRemoval(i)) {
+        for (final Component component : componentList) {
+            if (!component.isVisible()) {
                 component.clear(context);
                 continue;
             }

--- a/inventory-framework-core/src/test/java/me/devnatan/inventoryframework/pipeline/UpdateInterceptorTest.java
+++ b/inventory-framework-core/src/test/java/me/devnatan/inventoryframework/pipeline/UpdateInterceptorTest.java
@@ -3,11 +3,9 @@ package me.devnatan.inventoryframework.pipeline;
 import static me.devnatan.inventoryframework.TestUtils.createContextMock;
 import static me.devnatan.inventoryframework.TestUtils.createRootMock;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,36 +13,12 @@ import java.util.Collections;
 import me.devnatan.inventoryframework.RootView;
 import me.devnatan.inventoryframework.ViewContainer;
 import me.devnatan.inventoryframework.VirtualView;
-import me.devnatan.inventoryframework.component.Component;
 import me.devnatan.inventoryframework.component.ItemComponent;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.context.IFRenderContext;
 import org.junit.jupiter.api.Test;
 
 public class UpdateInterceptorTest {
-
-    @Test
-    void clearWhenMarkedForRemoval() {
-        Pipeline<VirtualView> pipeline = new Pipeline<>(StandardPipelinePhases.UPDATE);
-        pipeline.intercept(StandardPipelinePhases.UPDATE, new UpdateInterceptor());
-
-        RootView root = createRootMock();
-        IFContext context = createContextMock(root, IFRenderContext.class);
-        when(context.isShared()).thenReturn(true);
-        ViewContainer container = mock(ViewContainer.class);
-        when(context.getContainer()).thenReturn(container);
-
-        Component component = mock(Component.class);
-        when(context.isMarkedForRemoval(anyInt())).thenReturn(true);
-        when(context.getComponents()).thenReturn(Collections.singletonList(component));
-        when(root.getContexts()).thenReturn(Collections.singleton(context));
-
-        pipeline.execute(StandardPipelinePhases.UPDATE, context);
-
-        verify(component, times(1)).clear(eq(context));
-        verify(component, never()).updated(any());
-        verify(component, never()).render(any());
-    }
 
     @Test
     void neverRenderIfItemDoNotHaveRenderHandler() {

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
@@ -42,8 +42,7 @@ abstract class IFViewFrame<S extends IFViewFrame<S, V>, V extends PlatformView<S
         return getRegisteredViews().values().stream()
                 .filter(view -> view.getClass().equals(type))
                 .findFirst()
-                .orElseThrow(() ->
-                        new IllegalArgumentException(String.format("View not found or not registered: %s", type)));
+                .orElseThrow(() -> new IllegalArgumentException(String.format("View not registered: %s", type)));
     }
 
     /**

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -17,6 +17,7 @@ import me.devnatan.inventoryframework.context.IFRenderContext;
 import me.devnatan.inventoryframework.context.IFSlotClickContext;
 import me.devnatan.inventoryframework.context.IFSlotContext;
 import me.devnatan.inventoryframework.context.PlatformContext;
+import me.devnatan.inventoryframework.context.PlatformRenderContext;
 import me.devnatan.inventoryframework.internal.ElementFactory;
 import me.devnatan.inventoryframework.internal.PlatformUtils;
 import me.devnatan.inventoryframework.pipeline.AvailableSlotInterceptor;
@@ -252,6 +253,7 @@ public abstract class PlatformView<
     @ApiStatus.Internal
     public void renderContext(@NotNull TRenderContext context) {
         getPipeline().execute(context);
+        ((PlatformRenderContext<?, ?>) context).setRendered();
 
         @SuppressWarnings("rawtypes")
         final PlatformView view = (PlatformView) context.getRoot();

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -518,25 +518,6 @@ public abstract class PlatformView<
     }
 
     /**
-     * Creates a new immutable state of static pagination.
-     *
-     * @param sourceProvider The data source for pagination.
-     * @param itemFactory    The function for creating pagination items, this function is called for
-     *                       each paged element (item) on a page.
-     * @param <T>            The pagination data type.
-     * @return A new immutable pagination state.
-     * @deprecated Use {@link #paginationState(List, PaginationValueConsumer)} instead.
-     */
-    @Deprecated
-    @ApiStatus.ScheduledForRemoval(inVersion = "3.0.0")
-    protected final <T> State<Pagination> paginationState(
-            @NotNull List<? super T> sourceProvider, @NotNull BiConsumer<TItem, T> itemFactory) {
-        return this.<T>buildPaginationState(sourceProvider)
-                .itemFactory(itemFactory)
-                .build();
-    }
-
-    /**
      * Creates a new immutable pagination with static data source.
      *
      * @param sourceProvider The data source for pagination.
@@ -550,25 +531,6 @@ public abstract class PlatformView<
             @NotNull PaginationValueConsumer<TContext, TItem, T> elementConsumer) {
         return this.<T>buildPaginationState(sourceProvider)
                 .elementFactory(elementConsumer)
-                .build();
-    }
-
-    /**
-     * Creates a new unmodifiable dynamic pagination state.
-     *
-     * @param sourceProvider The data source for pagination.
-     * @param itemFactory    The function for creating pagination items, this function is called for
-     *                       each paged element (item) on a page.
-     * @param <T>            The pagination data type.
-     * @return A new immutable pagination state.
-     * @deprecated Use {@link #computedPaginationState(Function, PaginationValueConsumer)} instead.
-     */
-    @Deprecated
-    @ApiStatus.ScheduledForRemoval(inVersion = "3.0.0")
-    protected final <T> State<Pagination> paginationState(
-            @NotNull Function<TContext, List<? super T>> sourceProvider, @NotNull BiConsumer<TItem, T> itemFactory) {
-        return this.buildPaginationState(sourceProvider)
-                .itemFactory(itemFactory)
                 .build();
     }
 
@@ -666,47 +628,6 @@ public abstract class PlatformView<
     }
 
     /**
-     * Creates a new unmodifiable dynamic pagination state.
-     *
-     * @param sourceProvider The data source for pagination.
-     * @param itemFactory    The function for creating pagination items, this function is called for
-     *                       each paged element (item) on a page.
-     * @param <T>            The pagination data type.
-     * @return A new immutable pagination state.
-     * @deprecated Use {@link #computedPaginationState(Function, PaginationValueConsumer)} instead.
-     */
-    @Deprecated
-    protected final <T> State<Pagination> paginationState(
-            @NotNull Supplier<List<? super T>> sourceProvider, @NotNull BiConsumer<TItem, T> itemFactory) {
-        return this.buildPaginationState(sourceProvider)
-                .itemFactory(itemFactory)
-                .build();
-    }
-
-    /**
-     * Creates a new unmodifiable asynchronous pagination state.
-     * <p>
-     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
-     * such API may be changed or may be removed completely in any further release. </i></b>
-     *
-     * @param sourceProvider The asynchronous data source for pagination.
-     * @param itemFactory    The function for creating pagination items, this function is called for
-     *                       each paged element (item) on a page.
-     * @param <T>            The pagination data type.
-     * @return A new immutable pagination state.
-     * @deprecated
-     */
-    @Deprecated
-    @ApiStatus.Experimental
-    protected final <T> State<Pagination> asyncPaginationState(
-            @NotNull Function<TContext, CompletableFuture<List<T>>> sourceProvider,
-            @NotNull BiConsumer<TItem, T> itemFactory) {
-        return this.buildComputedAsyncPaginationState(sourceProvider)
-                .itemFactory(itemFactory)
-                .build();
-    }
-
-    /**
      * Creates a new unmodifiable static pagination state builder.
      *
      * @param sourceProvider The data source for pagination.
@@ -716,36 +637,6 @@ public abstract class PlatformView<
     protected final <T> PaginationStateBuilder<TContext, TItem, T> buildPaginationState(
             @NotNull List<? super T> sourceProvider) {
         return new PaginationStateBuilder<>(this, sourceProvider);
-    }
-
-    /**
-     * Creates a new unmodifiable dynamic pagination state builder.
-     *
-     * @param sourceProvider The data source for pagination.
-     * @param <T>            The pagination data type.
-     * @return A new pagination state builder.
-     * @deprecated Use {@link #buildComputedPaginationState(Supplier)} instead.
-     */
-    @Deprecated
-    @ApiStatus.ScheduledForRemoval(inVersion = "3.0.0")
-    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildPaginationState(
-            @NotNull Supplier<List<? super T>> sourceProvider) {
-        return new PaginationStateBuilder<>(this, sourceProvider, false, true);
-    }
-
-    /**
-     * Creates a new unmodifiable dynamic pagination state builder.
-     *
-     * @param sourceProvider The data source for pagination.
-     * @param <T>            The pagination data type.
-     * @return A new pagination state builder.
-     * @deprecated Use {@link #buildComputedPaginationState(Function)} instead.
-     */
-    @Deprecated
-    @ApiStatus.ScheduledForRemoval(inVersion = "3.0.0")
-    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildPaginationState(
-            @NotNull Function<TContext, List<? super T>> sourceProvider) {
-        return new PaginationStateBuilder<>(this, sourceProvider, false, true);
     }
 
     /**

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -516,14 +516,17 @@ public abstract class PlatformView<
     }
 
     /**
-     * Creates a new unmodifiable static pagination state.
+     * Creates a new immutable state of static pagination.
      *
      * @param sourceProvider The data source for pagination.
      * @param itemFactory    The function for creating pagination items, this function is called for
      *                       each paged element (item) on a page.
      * @param <T>            The pagination data type.
      * @return A new immutable pagination state.
+     * @deprecated Use {@link #paginationState(List, PaginationValueConsumer)} instead.
      */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "3.0.0")
     protected final <T> State<Pagination> paginationState(
             @NotNull List<? super T> sourceProvider, @NotNull BiConsumer<TItem, T> itemFactory) {
         return this.<T>buildPaginationState(sourceProvider)
@@ -532,19 +535,19 @@ public abstract class PlatformView<
     }
 
     /**
-     * Creates a new unmodifiable static pagination state.
+     * Creates a new immutable pagination with static data source.
      *
      * @param sourceProvider The data source for pagination.
-     * @param itemFactory    The function for creating pagination items, this function is called for
+     * @param elementConsumer    The function for creating pagination items, this function is called for
      *                       each paged element (item) on a page.
      * @param <T>            The pagination data type.
      * @return A new immutable pagination state.
      */
     protected final <T> State<Pagination> paginationState(
             @NotNull List<? super T> sourceProvider,
-            @NotNull PaginationElementConsumer<TContext, TItem, T> itemFactory) {
+            @NotNull PaginationValueConsumer<TContext, TItem, T> elementConsumer) {
         return this.<T>buildPaginationState(sourceProvider)
-                .itemFactory(itemFactory)
+                .elementFactory(elementConsumer)
                 .build();
     }
 
@@ -556,7 +559,10 @@ public abstract class PlatformView<
      *                       each paged element (item) on a page.
      * @param <T>            The pagination data type.
      * @return A new immutable pagination state.
+     * @deprecated Use {@link #computedPaginationState(Function, PaginationValueConsumer)} instead.
      */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "3.0.0")
     protected final <T> State<Pagination> paginationState(
             @NotNull Function<TContext, List<? super T>> sourceProvider, @NotNull BiConsumer<TItem, T> itemFactory) {
         return this.buildPaginationState(sourceProvider)
@@ -565,19 +571,57 @@ public abstract class PlatformView<
     }
 
     /**
-     * Creates a new unmodifiable dynamic pagination state.
+     * Creates a new unmodifiable computed pagination state.
      *
-     * @param sourceProvider The data source for pagination.
-     * @param itemFactory    The function for creating pagination items, this function is called for
+     * @param sourceProvider Data source for pagination.
+     * @param valueConsumer  Function for creating pagination items, this function is called for
      *                       each paged element (item) on a page.
      * @param <T>            The pagination data type.
-     * @return A new immutable pagination state.
+     * @return A new unmodifiable pagination state.
      */
-    protected final <T> State<Pagination> paginationState(
+    protected final <T> State<Pagination> computedPaginationState(
             @NotNull Function<TContext, List<? super T>> sourceProvider,
-            @NotNull PaginationElementConsumer<TContext, TItem, T> itemFactory) {
+            @NotNull PaginationValueConsumer<TContext, TItem, T> valueConsumer) {
         return this.buildPaginationState(sourceProvider)
-                .itemFactory(itemFactory)
+                .elementFactory(valueConsumer)
+                .build();
+    }
+
+    /**
+     * Creates a new unmodifiable computed pagination state.
+     *
+     * @param sourceProvider Data source for pagination.
+     * @param valueConsumer  Function for creating pagination items, this function is called for
+     *                       each paged element (item) on a page.
+     * @param <T>            The pagination data type.
+     * @return A new unmodifiable pagination state.
+     */
+    protected final <T> State<Pagination> computedPaginationState(
+            @NotNull Supplier<List<? super T>> sourceProvider,
+            @NotNull PaginationValueConsumer<TContext, TItem, T> valueConsumer) {
+        return this.buildPaginationState(sourceProvider)
+                .elementFactory(valueConsumer)
+                .build();
+    }
+
+    /**
+     * Creates a new unmodifiable computed pagination state with asynchronous data source.
+     * <p>
+     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param sourceProvider The data source for pagination.
+     * @param valueConsumer    The function for creating pagination items, this function is called for
+     *                       each paged element (item) on a page.
+     * @param <T>            The pagination data type.
+     * @return A new unmodifiable pagination state.
+     */
+    @ApiStatus.Experimental
+    protected final <T> State<Pagination> computedAsyncPaginationState(
+            @NotNull Function<TContext, CompletableFuture<List<T>>> sourceProvider,
+            @NotNull PaginationValueConsumer<TContext, TItem, T> valueConsumer) {
+        return this.buildComputedAsyncPaginationState(sourceProvider)
+                .elementFactory(valueConsumer)
                 .build();
     }
 
@@ -589,7 +633,9 @@ public abstract class PlatformView<
      *                       each paged element (item) on a page.
      * @param <T>            The pagination data type.
      * @return A new immutable pagination state.
+     * @deprecated Use {@link #computedPaginationState(Function, PaginationValueConsumer)} instead.
      */
+    @Deprecated
     protected final <T> State<Pagination> paginationState(
             @NotNull Supplier<List<? super T>> sourceProvider, @NotNull BiConsumer<TItem, T> itemFactory) {
         return this.buildPaginationState(sourceProvider)
@@ -598,23 +644,6 @@ public abstract class PlatformView<
     }
 
     /**
-     * Creates a new unmodifiable dynamic pagination state.
-     *
-     * @param sourceProvider The data source for pagination.
-     * @param itemFactory    The function for creating pagination items, this function is called for
-     *                       each paged element (item) on a page.
-     * @param <T>            The pagination data type.
-     * @return A new immutable pagination state.
-     */
-    protected final <T> State<Pagination> paginationState(
-            @NotNull Supplier<List<? super T>> sourceProvider,
-            @NotNull PaginationElementConsumer<TContext, TItem, T> itemFactory) {
-        return this.buildPaginationState(sourceProvider)
-                .itemFactory(itemFactory)
-                .build();
-    }
-
-    /**
      * Creates a new unmodifiable asynchronous pagination state.
      * <p>
      * <b><i> This API is experimental and is not subject to the general compatibility guarantees
@@ -625,33 +654,14 @@ public abstract class PlatformView<
      *                       each paged element (item) on a page.
      * @param <T>            The pagination data type.
      * @return A new immutable pagination state.
+     * @deprecated
      */
+    @Deprecated
     @ApiStatus.Experimental
     protected final <T> State<Pagination> asyncPaginationState(
             @NotNull Function<TContext, CompletableFuture<List<T>>> sourceProvider,
             @NotNull BiConsumer<TItem, T> itemFactory) {
-        return this.buildAsyncPaginationState(sourceProvider)
-                .itemFactory(itemFactory)
-                .build();
-    }
-
-    /**
-     * Creates a new unmodifiable asynchronous pagination state.
-     * <p>
-     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
-     * such API may be changed or may be removed completely in any further release. </i></b>
-     *
-     * @param sourceProvider The asynchronous data source for pagination.
-     * @param itemFactory    The function for creating pagination items, this function is called for
-     *                       each paged element (item) on a page.
-     * @param <T>            The pagination data type.
-     * @return A new immutable pagination state.
-     */
-    @ApiStatus.Experimental
-    protected final <T> State<Pagination> asyncPaginationState(
-            @NotNull Function<TContext, CompletableFuture<List<T>>> sourceProvider,
-            @NotNull PaginationElementConsumer<TContext, TItem, T> itemFactory) {
-        return this.buildAsyncPaginationState(sourceProvider)
+        return this.buildComputedAsyncPaginationState(sourceProvider)
                 .itemFactory(itemFactory)
                 .build();
     }
@@ -663,7 +673,7 @@ public abstract class PlatformView<
      * @param <T>            The pagination data type.
      * @return A new pagination state builder.
      */
-    protected final <T> PaginationStateBuilder<TContext, TSlotClickContext, TItem, T> buildPaginationState(
+    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildPaginationState(
             @NotNull List<? super T> sourceProvider) {
         return new PaginationStateBuilder<>(this, sourceProvider);
     }
@@ -674,10 +684,28 @@ public abstract class PlatformView<
      * @param sourceProvider The data source for pagination.
      * @param <T>            The pagination data type.
      * @return A new pagination state builder.
+     * @deprecated Use {@link #buildComputedPaginationState(Supplier)} instead.
      */
-    protected final <T> PaginationStateBuilder<TContext, TSlotClickContext, TItem, T> buildPaginationState(
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "3.0.0")
+    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildPaginationState(
             @NotNull Supplier<List<? super T>> sourceProvider) {
-        return new PaginationStateBuilder<>(this, sourceProvider);
+        return new PaginationStateBuilder<>(this, sourceProvider, false, true);
+    }
+
+    /**
+     * Creates a new unmodifiable dynamic pagination state builder.
+     *
+     * @param sourceProvider The data source for pagination.
+     * @param <T>            The pagination data type.
+     * @return A new pagination state builder.
+     * @deprecated Use {@link #buildComputedPaginationState(Function)} instead.
+     */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "3.0.0")
+    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildPaginationState(
+            @NotNull Function<TContext, List<? super T>> sourceProvider) {
+        return new PaginationStateBuilder<>(this, sourceProvider, false, true);
     }
 
     /**
@@ -687,9 +715,21 @@ public abstract class PlatformView<
      * @param <T>            The pagination data type.
      * @return A new pagination state builder.
      */
-    protected final <T> PaginationStateBuilder<TContext, TSlotClickContext, TItem, T> buildPaginationState(
+    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildComputedPaginationState(
+            @NotNull Supplier<List<? super T>> sourceProvider) {
+        return new PaginationStateBuilder<>(this, sourceProvider, false, true);
+    }
+
+    /**
+     * Creates a new unmodifiable dynamic pagination state builder.
+     *
+     * @param sourceProvider The data source for pagination.
+     * @param <T>            The pagination data type.
+     * @return A new pagination state builder.
+     */
+    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildComputedPaginationState(
             @NotNull Function<TContext, List<? super T>> sourceProvider) {
-        return new PaginationStateBuilder<>(this, sourceProvider);
+        return new PaginationStateBuilder<>(this, sourceProvider, false, true);
     }
 
     /**
@@ -703,23 +743,24 @@ public abstract class PlatformView<
      * @return A new pagination state builder.
      */
     @ApiStatus.Experimental
-    protected final <T> PaginationStateBuilder<TContext, TSlotClickContext, TItem, T> buildAsyncPaginationState(
+    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildComputedAsyncPaginationState(
             @NotNull Function<TContext, CompletableFuture<List<T>>> sourceProvider) {
-        return new PaginationStateBuilder<>(this, sourceProvider);
+        return new PaginationStateBuilder<>(this, sourceProvider, true, false);
     }
 
-    final <V> State<Pagination> buildPaginationState(
-            @NotNull PaginationStateBuilder<TContext, TSlotContext, TItem, V> builder) {
+    final <V> State<Pagination> createPaginationState(@NotNull PaginationStateBuilder<TContext, TItem, V> builder) {
         requireNotInitialized();
         final long id = State.next();
         @SuppressWarnings("unchecked")
         final StateValueFactory factory = (host, state) -> new PaginationImpl(
                 state,
-                (TContext) host,
+                (IFContext) host,
                 builder.getLayoutTarget(),
                 builder.getSourceProvider(),
                 (PaginationElementFactory<IFContext, Object>) builder.getElementFactory(),
-                (BiConsumer<IFContext, Pagination>) builder.getPageSwitchHandler());
+                (BiConsumer<IFContext, Pagination>) builder.getPageSwitchHandler(),
+                builder.isAsync(),
+                builder.isComputed());
         final State<Pagination> state = new PaginationState(id, factory);
         stateRegistry.registerState(state, this);
 

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -584,7 +584,7 @@ public abstract class PlatformView<
     protected final <T> State<Pagination> computedPaginationState(
             @NotNull Function<TContext, List<? super T>> sourceProvider,
             @NotNull PaginationValueConsumer<TContext, TItem, T> valueConsumer) {
-        return this.buildPaginationState(sourceProvider)
+        return this.buildComputedPaginationState(sourceProvider)
                 .elementFactory(valueConsumer)
                 .build();
     }
@@ -601,7 +601,7 @@ public abstract class PlatformView<
     protected final <T> State<Pagination> computedPaginationState(
             @NotNull Supplier<List<? super T>> sourceProvider,
             @NotNull PaginationValueConsumer<TContext, TItem, T> valueConsumer) {
-        return this.buildPaginationState(sourceProvider)
+        return this.buildComputedPaginationState(sourceProvider)
                 .elementFactory(valueConsumer)
                 .build();
     }

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -590,23 +590,6 @@ public abstract class PlatformView<
     }
 
     /**
-     * Creates a new unmodifiable computed pagination state.
-     *
-     * @param sourceProvider Data source for pagination.
-     * @param valueConsumer  Function for creating pagination items, this function is called for
-     *                       each paged element (item) on a page.
-     * @param <T>            The pagination data type.
-     * @return A new unmodifiable pagination state.
-     */
-    protected final <T> State<Pagination> computedPaginationState(
-            @NotNull Supplier<List<? super T>> sourceProvider,
-            @NotNull PaginationValueConsumer<TContext, TItem, T> valueConsumer) {
-        return this.buildComputedPaginationState(sourceProvider)
-                .elementFactory(valueConsumer)
-                .build();
-    }
-
-    /**
      * Creates a new unmodifiable computed pagination state with asynchronous data source.
      * <p>
      * <b><i> This API is experimental and is not subject to the general compatibility guarantees
@@ -623,6 +606,61 @@ public abstract class PlatformView<
             @NotNull Function<TContext, CompletableFuture<List<T>>> sourceProvider,
             @NotNull PaginationValueConsumer<TContext, TItem, T> valueConsumer) {
         return this.buildComputedAsyncPaginationState(sourceProvider)
+                .elementFactory(valueConsumer)
+                .build();
+    }
+
+    /**
+     * Creates a new unmodifiable lazy pagination state.
+     *
+     * @param sourceProvider Data source for pagination.
+     * @param valueConsumer  Function for creating pagination items, this function is called for
+     *                       each paged element (item) on a page.
+     * @param <T>            The pagination data type.
+     * @return A new unmodifiable pagination state.
+     */
+    protected final <T> State<Pagination> lazyPaginationState(
+            @NotNull Function<TContext, List<? super T>> sourceProvider,
+            @NotNull PaginationValueConsumer<TContext, TItem, T> valueConsumer) {
+        return this.buildLazyPaginationState(sourceProvider)
+                .elementFactory(valueConsumer)
+                .build();
+    }
+
+    /**
+     * Creates a new unmodifiable lazy pagination state.
+     *
+     * @param sourceProvider Data source for pagination.
+     * @param valueConsumer  Function for creating pagination items, this function is called for
+     *                       each paged element (item) on a page.
+     * @param <T>            The pagination data type.
+     * @return A new unmodifiable pagination state.
+     */
+    protected final <T> State<Pagination> lazyPaginationState(
+            @NotNull Supplier<List<? super T>> sourceProvider,
+            @NotNull PaginationValueConsumer<TContext, TItem, T> valueConsumer) {
+        return this.buildLazyPaginationState(sourceProvider)
+                .elementFactory(valueConsumer)
+                .build();
+    }
+
+    /**
+     * Creates a new unmodifiable lazy pagination state with asynchronous data source.
+     * <p>
+     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param sourceProvider The data source for pagination.
+     * @param valueConsumer    The function for creating pagination items, this function is called for
+     *                       each paged element (item) on a page.
+     * @param <T>            The pagination data type.
+     * @return A new unmodifiable pagination state.
+     */
+    @ApiStatus.Experimental
+    protected final <T> State<Pagination> lazyAsyncPaginationState(
+            @NotNull Function<TContext, CompletableFuture<List<T>>> sourceProvider,
+            @NotNull PaginationValueConsumer<TContext, TItem, T> valueConsumer) {
+        return this.buildLazyAsyncPaginationState(sourceProvider)
                 .elementFactory(valueConsumer)
                 .build();
     }
@@ -718,24 +756,12 @@ public abstract class PlatformView<
      * @return A new pagination state builder.
      */
     protected final <T> PaginationStateBuilder<TContext, TItem, T> buildComputedPaginationState(
-            @NotNull Supplier<List<? super T>> sourceProvider) {
-        return new PaginationStateBuilder<>(this, sourceProvider, false, true);
-    }
-
-    /**
-     * Creates a new unmodifiable dynamic pagination state builder.
-     *
-     * @param sourceProvider The data source for pagination.
-     * @param <T>            The pagination data type.
-     * @return A new pagination state builder.
-     */
-    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildComputedPaginationState(
             @NotNull Function<TContext, List<? super T>> sourceProvider) {
         return new PaginationStateBuilder<>(this, sourceProvider, false, true);
     }
 
     /**
-     * Creates a new unmodifiable asynchronous pagination state builder.
+     * Creates a new unmodifiable computed pagination state builder with asynchronous data source.
      * <p>
      * <b><i> This API is experimental and is not subject to the general compatibility guarantees
      * such API may be changed or may be removed completely in any further release. </i></b>
@@ -746,6 +772,46 @@ public abstract class PlatformView<
      */
     @ApiStatus.Experimental
     protected final <T> PaginationStateBuilder<TContext, TItem, T> buildComputedAsyncPaginationState(
+            @NotNull Function<TContext, CompletableFuture<List<T>>> sourceProvider) {
+        return new PaginationStateBuilder<>(this, sourceProvider, true, true);
+    }
+
+    /**
+     * Creates a new unmodifiable lazy pagination state builder.
+     *
+     * @param sourceProvider The data source for pagination.
+     * @param <T>            The pagination data type.
+     * @return A new pagination state builder.
+     */
+    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildLazyPaginationState(
+            @NotNull Supplier<List<? super T>> sourceProvider) {
+        return new PaginationStateBuilder<>(this, sourceProvider, false, false);
+    }
+
+    /**
+     * Creates a new unmodifiable lazy pagination state builder.
+     *
+     * @param sourceProvider The data source for pagination.
+     * @param <T>            The pagination data type.
+     * @return A new pagination state builder.
+     */
+    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildLazyPaginationState(
+            @NotNull Function<TContext, List<? super T>> sourceProvider) {
+        return new PaginationStateBuilder<>(this, sourceProvider, false, false);
+    }
+
+    /**
+     * Creates a new unmodifiable lazy pagination state builder with asynchronous data source.
+     * <p>
+     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param sourceProvider The data source for pagination.
+     * @param <T>            The pagination data type.
+     * @return A new pagination state builder.
+     */
+    @ApiStatus.Experimental
+    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildLazyAsyncPaginationState(
             @NotNull Function<TContext, CompletableFuture<List<T>>> sourceProvider) {
         return new PaginationStateBuilder<>(this, sourceProvider, true, false);
     }

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformRenderContext.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformRenderContext.java
@@ -37,6 +37,7 @@ public abstract class PlatformRenderContext<T extends ItemComponentBuilder<T, C>
 
     // --- Inherited ---
     private final ViewContainer container;
+    private boolean rendered;
 
     // --- Properties ---
     private final List<ComponentFactory> componentBuilders = new ArrayList<>();
@@ -325,5 +326,19 @@ public abstract class PlatformRenderContext<T extends ItemComponentBuilder<T, C>
     public final void resetTitleForPlayer() {
         tryThrowDoNotWorkWithSharedContext("resetTitleForEveryone()");
         super.resetTitleForPlayer();
+    }
+
+    @Override
+    public final boolean isRendered() {
+        return rendered;
+    }
+
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    public final void setRendered() {
+        this.rendered = true;
     }
 }

--- a/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
+++ b/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
@@ -88,5 +88,8 @@ public class FakeComponent implements Component, InteractionHandler {
     }
 
     @Override
+    public void update() {}
+
+    @Override
     public void clicked(@NotNull Component component, @NotNull IFSlotClickContext context) {}
 }


### PR DESCRIPTION
Fixes #453

paginationState methods that accepts Function-like parameter as source provider is now `computedPaginationState` to match `computedState`. Computed state is used to create endless pagination so only `Function` is accepted as source provider (`Supplier` was removed).

`asyncPaginationState` is now `computedAsyncPaginationState` to match `computedState` as well.
`lazyPaginationState` introduced to match `lazyState`.