### PR TITLE
Check overlaps in ComponentComposition child as well

### DIFF
--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Component.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Component.java
@@ -123,6 +123,8 @@ public interface Component extends VirtualView {
      * @return If component B area conflicts with area of component A.
      */
     static boolean intersects(@NotNull Component component, @NotNull Component other) {
+        if (component instanceof ComponentComposition) return intersects(other, component);
+
         if (other instanceof ComponentComposition) {
             for (final Component otherChildren : (ComponentComposition) other) {
                 if (otherChildren.intersects(component)) return true;

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ComponentComposition.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ComponentComposition.java
@@ -1,20 +1,9 @@
 package me.devnatan.inventoryframework.component;
 
-import java.util.List;
-import org.jetbrains.annotations.UnmodifiableView;
-
 /**
  * A component whose is composed of multiple components.
  */
-public interface ComponentComposition extends Component, Iterable<Component> {
-
-    /**
-     * All components in this composition.
-     *
-     * @return An unmodifiable view of all components in this composition.
-     */
-    @UnmodifiableView
-    List<Component> getComponents();
+public interface ComponentComposition extends Component, ComponentContainer {
 
     /**
      * Checks if any component of that composition is in a specific position.

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ComponentContainer.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ComponentContainer.java
@@ -1,0 +1,15 @@
+package me.devnatan.inventoryframework.component;
+
+import java.util.List;
+import org.jetbrains.annotations.UnmodifiableView;
+
+public interface ComponentContainer extends Iterable<Component> {
+
+    /**
+     * All components in this container.
+     *
+     * @return An unmodifiable view of all components in this container.
+     */
+    @UnmodifiableView
+    List<Component> getComponents();
+}

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFContext.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFContext.java
@@ -8,12 +8,13 @@ import me.devnatan.inventoryframework.ViewConfig;
 import me.devnatan.inventoryframework.Viewer;
 import me.devnatan.inventoryframework.VirtualView;
 import me.devnatan.inventoryframework.component.Component;
+import me.devnatan.inventoryframework.component.ComponentContainer;
 import me.devnatan.inventoryframework.state.StateValueHost;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnmodifiableView;
 
-public interface IFContext extends VirtualView, StateValueHost {
+public interface IFContext extends VirtualView, StateValueHost, ComponentContainer {
 
     /**
      * An unique id for this context.


### PR DESCRIPTION
Child components (components whose root is a Component and not a IFContext) were being ignored in the component overlap check. Also caused its root to be re-rendered X times, with   being the number of components that had `displayIf` in the view and that its position interfered with the position of the root of these components.

Ex.: a Clock item interfering in Pagination (see code below)

###### Code

```java
State<Pagination> paginationState = lazyPaginationState(
    (context) -> IntStream.range(0, 50).boxed().collect(Collectors.toList()), 
    (context, builder, index, value) -> {
        builder.withItem(new ItemStack(Material.DIAMOND));
    }
);


@Override
public void onFirstRender(@NotNull RenderContext render) {
    Pagination pagination = paginationState.get(render);
    
    render.firstSlot(new ItemStack(Material.CLOCK))
        .displayIf(pagination::isLoading);
}
```

###### Result

| Before | After |
|:------:|:-----:|
| <img width="349" alt="Screenshot 2023-09-13 at 14 28 21" src="https://github.com/DevNatan/inventory-framework/assets/24600258/918db4ca-3a86-41f6-83a7-affa201e4918"> | <img width="349" alt="Screenshot 2023-09-13 at 14 52 11" src="https://github.com/DevNatan/inventory-framework/assets/24600258/1057b04c-9689-4bc5-aaf4-1f5a6b271591"> |