### PR TITLE
Fix usage of `displayIf` and `watch` in pagination items

### DIFF
--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Component.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Component.java
@@ -15,6 +15,13 @@ import org.jetbrains.annotations.UnmodifiableView;
 public interface Component extends VirtualView {
 
     /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    String getKey();
+
+    /**
      * The root of this component.
      *
      * @return The root of this component.

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ComponentContainer.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ComponentContainer.java
@@ -1,6 +1,7 @@
 package me.devnatan.inventoryframework.component;
 
 import java.util.List;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.UnmodifiableView;
 
 public interface ComponentContainer extends Iterable<Component> {
@@ -12,4 +13,11 @@ public interface ComponentContainer extends Iterable<Component> {
      */
     @UnmodifiableView
     List<Component> getComponents();
+
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    List<Component> getInternalComponents();
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
@@ -3,6 +3,7 @@ package me.devnatan.inventoryframework.component;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import me.devnatan.inventoryframework.InventoryFrameworkException;
@@ -15,6 +16,7 @@ import org.jetbrains.annotations.UnmodifiableView;
 // TODO Make this render abstract and remove `getResult` (Object) from IFSlotRenderContext
 public class ItemComponent implements Component, InteractionHandler {
 
+    private final String key = UUID.randomUUID().toString();
     private final VirtualView root;
     private int position;
     private final Object stack;
@@ -56,6 +58,11 @@ public class ItemComponent implements Component, InteractionHandler {
         this.isManagedExternally = isManagedExternally;
         this.updateOnClick = updateOnClick;
         this.isVisible = isVisible;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
     }
 
     @NotNull
@@ -230,8 +237,7 @@ public class ItemComponent implements Component, InteractionHandler {
 
     @Override
     public String toString() {
-        return "ItemComponent{" + "root="
-                + root + ", position="
+        return "ItemComponent{" + ", position="
                 + position + ", stack="
                 + stack + ", cancelOnClick="
                 + cancelOnClick + ", closeOnClick="
@@ -240,7 +246,8 @@ public class ItemComponent implements Component, InteractionHandler {
                 + renderHandler + ", updateHandler="
                 + updateHandler + ", clickHandler="
                 + clickHandler + ", watching="
-                + watching + ", isManagedExternally="
+                + watching + ", isVisible="
+                + isVisible + ", isManagedExternally="
                 + isManagedExternally + '}';
     }
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/PaginationElementFactory.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/PaginationElementFactory.java
@@ -1,7 +1,7 @@
 package me.devnatan.inventoryframework.component;
 
 @FunctionalInterface
-public interface PaginationElementFactory<Context, V> {
+public interface PaginationElementFactory<V> {
 
-    ComponentFactory create(Context context, int index, int slot, V value);
+    ComponentFactory create(Pagination root, int index, int slot, V value);
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFContext.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFContext.java
@@ -99,15 +99,6 @@ public interface IFContext extends VirtualView, StateValueHost, ComponentContain
     String getInitialTitle();
 
     /**
-     * All components in this context.
-     *
-     * @return An unmodifiable List view of all components in this context.
-     */
-    @NotNull
-    @UnmodifiableView
-    List<Component> getComponents();
-
-    /**
      * Gets the component that is at a certain position.
      *
      * <p><b><i>This is an internal inventory-framework API that should not be used from outside of
@@ -117,7 +108,7 @@ public interface IFContext extends VirtualView, StateValueHost, ComponentContain
      * @return The component in the given position or {@code null}.
      */
     @ApiStatus.Internal
-    Component getComponent(int position);
+    List<Component> getComponentsAt(int position);
 
     /**
      * Adds a new component to this context.

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 @VisibleForTesting
 public class PaginationImpl extends AbstractStateValue implements Pagination, InteractionHandler {
 
-	private final String key = UUID.randomUUID().toString();
+    private final String key = UUID.randomUUID().toString();
     private List<Component> components = new ArrayList<>();
     private final IFContext host;
     private boolean visible;
@@ -305,7 +305,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         return host;
     }
 
-	@Override
+    @Override
     public Object get() {
         return this;
     }
@@ -315,12 +315,12 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         // do nothing since Pagination is not immutable but unmodifiable directly
     }
 
-	@Override
-	public String getKey() {
-		return key;
-	}
+    @Override
+    public String getKey() {
+        return key;
+    }
 
-	@Override
+    @Override
     public @NotNull VirtualView getRoot() {
         return host;
     }
@@ -409,12 +409,12 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         return Collections.unmodifiableList(getInternalComponents());
     }
 
-	@Override
-	public List<Component> getInternalComponents() {
-		return components;
-	}
+    @Override
+    public List<Component> getInternalComponents() {
+        return components;
+    }
 
-	@Override
+    @Override
     public boolean isContainedWithin(int position) {
         for (final Component component : getInternalComponents()) {
             if (component.isContainedWithin(position)) return true;
@@ -567,7 +567,10 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         if (pageWasChanged) return;
 
         for (final Component child : getInternalComponents()) {
-            if (child.getInteractionHandler() == null || !child.isVisible()) continue;
+            if (child.getInteractionHandler() == null || !child.isVisible()) {
+                continue;
+            }
+            ;
             if (child.isContainedWithin(context.getClickedSlot())) {
                 child.getInteractionHandler().clicked(component, context);
                 break;

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -26,6 +27,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 @VisibleForTesting
 public class PaginationImpl extends AbstractStateValue implements Pagination, InteractionHandler {
 
+	private final String key = UUID.randomUUID().toString();
     private List<Component> components = new ArrayList<>();
     private final IFContext host;
     private boolean visible;
@@ -33,7 +35,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
     // --- User provided ---
     private final char layoutTarget;
     private final Object sourceProvider;
-    private final PaginationElementFactory<IFContext, Object> elementFactory;
+    private final PaginationElementFactory<Object> elementFactory;
     private final BiConsumer<IFContext, Pagination> pageSwitchHandler;
 
     // --- Internal ---
@@ -65,7 +67,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
             IFContext host,
             char layoutTarget,
             Object sourceProvider,
-            PaginationElementFactory<IFContext, Object> elementFactory,
+            PaginationElementFactory<Object> elementFactory,
             BiConsumer<IFContext, Pagination> pageSwitchHandler,
             boolean isAsync,
             boolean isComputed) {
@@ -201,8 +203,8 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         final int lastSlot = Math.min(container.getLastSlot() + 1 /* inclusive */, pageContents.size());
         for (int i = container.getFirstSlot(); i < lastSlot; i++) {
             final Object value = pageContents.get(i);
-            final ComponentFactory factory = elementFactory.create(context, i, i, value);
-            getComponentsInternal().add(factory.create());
+            final ComponentFactory factory = elementFactory.create(this, i, i, value);
+            getInternalComponents().add(factory.create());
         }
     }
 
@@ -223,10 +225,10 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         int iterationIndex = 0;
         for (final int position : targetLayoutSlot.getPositions()) {
             final Object value = pageContents.get(iterationIndex++);
-            final ComponentFactory factory = elementFactory.create(context, iterationIndex, position, value);
+            final ComponentFactory factory = elementFactory.create(this, iterationIndex, position, value);
             final Component component = factory.create();
 
-            getComponentsInternal().add(component);
+            getInternalComponents().add(component);
 
             if (iterationIndex == elementsLen) break;
         }
@@ -303,7 +305,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         return host;
     }
 
-    @Override
+	@Override
     public Object get() {
         return this;
     }
@@ -313,14 +315,19 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         // do nothing since Pagination is not immutable but unmodifiable directly
     }
 
-    @Override
+	@Override
+	public String getKey() {
+		return key;
+	}
+
+	@Override
     public @NotNull VirtualView getRoot() {
         return host;
     }
 
     @Override
     public int getPosition() {
-        final List<Component> components = getComponentsInternal();
+        final List<Component> components = getInternalComponents();
         if (components.isEmpty()) return 0;
 
         final int first = components.get(0).getPosition();
@@ -344,7 +351,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
     }
 
     private void renderChild(IFSlotRenderContext context) {
-        getComponentsInternal().forEach(child -> child.render(context));
+        getInternalComponents().forEach(context::renderComponent);
     }
 
     @Override
@@ -353,9 +360,9 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
 
         // If page was changed all components will be removed, so don't trigger update on them
         if (pageWasChanged) {
-            getComponentsInternal().forEach(child -> child.clear(renderContext));
+            getInternalComponents().forEach(child -> child.clear(renderContext));
             components = new ArrayList<>();
-            getComponentsInternal().clear();
+            getInternalComponents().clear();
             loadCurrentPage(renderContext).thenRun(() -> {
                 render(context);
                 simulateStateUpdate();
@@ -364,7 +371,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
             return;
         }
 
-        getComponentsInternal().forEach(child -> child.updated(context));
+        getInternalComponents().forEach(child -> child.updated(context));
     }
 
     /**
@@ -380,11 +387,11 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
     @Override
     public void clear(@NotNull IFContext context) {
         if (!pageWasChanged) {
-            getComponentsInternal().forEach(child -> child.clear(context));
+            getInternalComponents().forEach(child -> child.clear(context));
             return;
         }
 
-        final Iterator<Component> childIterator = getComponentsInternal().iterator();
+        final Iterator<Component> childIterator = getInternalComponents().iterator();
         while (childIterator.hasNext()) {
             Component child = childIterator.next();
             child.clear(context);
@@ -399,12 +406,17 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
 
     @Override
     public @UnmodifiableView List<Component> getComponents() {
-        return Collections.unmodifiableList(components);
+        return Collections.unmodifiableList(getInternalComponents());
     }
 
-    @Override
+	@Override
+	public List<Component> getInternalComponents() {
+		return components;
+	}
+
+	@Override
     public boolean isContainedWithin(int position) {
-        for (final Component component : getComponentsInternal()) {
+        for (final Component component : getInternalComponents()) {
             if (component.isContainedWithin(position)) return true;
         }
         return false;
@@ -546,7 +558,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
     @Override
     public void setVisible(boolean visible) {
         this.visible = visible;
-        getComponentsInternal().forEach(component -> component.setVisible(visible));
+        getInternalComponents().forEach(component -> component.setVisible(visible));
     }
 
     @Override
@@ -554,8 +566,8 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         // Lock child interactions while page is being updated
         if (pageWasChanged) return;
 
-        for (final Component child : getComponentsInternal()) {
-            if (child.getInteractionHandler() == null) continue;
+        for (final Component child : getInternalComponents()) {
+            if (child.getInteractionHandler() == null || !child.isVisible()) continue;
             if (child.isContainedWithin(context.getClickedSlot())) {
                 child.getInteractionHandler().clicked(component, context);
                 break;
@@ -576,11 +588,6 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
     @Override
     public void update() {
         ((IFContext) getRoot()).updateComponent(this);
-    }
-
-    @VisibleForTesting
-    List<Component> getComponentsInternal() {
-        return components;
     }
 
     @Override

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/FirstRenderInterceptor.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/FirstRenderInterceptor.java
@@ -3,6 +3,7 @@ package me.devnatan.inventoryframework.pipeline;
 import java.util.List;
 import me.devnatan.inventoryframework.VirtualView;
 import me.devnatan.inventoryframework.component.Component;
+import me.devnatan.inventoryframework.component.ComponentComposition;
 import me.devnatan.inventoryframework.component.ComponentFactory;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.context.IFRenderContext;
@@ -30,6 +31,12 @@ public final class FirstRenderInterceptor implements PipelineInterceptor<Virtual
             // TODO Setup watches on context initialization not on first render
             setupWatchers(context, component);
             context.renderComponent(component);
+
+            if (component instanceof ComponentComposition) {
+                for (final Component child : (ComponentComposition) component) {
+                    setupWatchers(context, child);
+                }
+            }
         }
     }
 

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/IFInventoryListener.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/IFInventoryListener.java
@@ -42,7 +42,10 @@ final class IFInventoryListener implements Listener {
         if (viewer == null) return;
 
         final IFRenderContext context = viewer.getActiveContext();
-        final Component clickedComponent = context.getComponent(event.getRawSlot());
+        final Component clickedComponent = context.getComponentsAt(event.getRawSlot()).stream()
+                .filter(Component::isVisible)
+                .findFirst()
+                .orElse(null);
         final ViewContainer clickedContainer = event.getClickedInventory() instanceof PlayerInventory
                 ? viewer.getSelfContainer()
                 : context.getContainer();

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/SlotContext.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/SlotContext.java
@@ -62,8 +62,13 @@ public abstract class SlotContext extends PlatformContext implements IFSlotConte
     }
 
     @Override
-    public final Component getComponent(int position) {
-        return getParent().getComponent(position);
+    public List<Component> getInternalComponents() {
+        return getParent().getInternalComponents();
+    }
+
+    @Override
+    public final List<Component> getComponentsAt(int position) {
+        return getParent().getComponentsAt(position);
     }
 
     @Override

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/pipeline/ItemClickInterceptor.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/pipeline/ItemClickInterceptor.java
@@ -22,7 +22,7 @@ public final class ItemClickInterceptor implements PipelineInterceptor<VirtualVi
         if (event.getSlotType() == InventoryType.SlotType.OUTSIDE) return;
 
         final Component component = context.getComponent();
-        if (component == null || !component.isVisible()) return;
+        if (component == null) return;
 
         if (component instanceof ItemComponent) {
             final ItemComponent item = (ItemComponent) component;

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PaginationStateBuilder.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PaginationStateBuilder.java
@@ -14,7 +14,7 @@ public final class PaginationStateBuilder<
     private final PlatformView root;
     private final Object sourceProvider;
     private char layoutTarget = LayoutSlot.FILLED_RESERVED_CHAR;
-    private PaginationElementFactory<Context, V> elementFactory;
+    private PaginationElementFactory<V> elementFactory;
     private BiConsumer<Context, Pagination> pageSwitchHandler;
     private final boolean async, computed;
 
@@ -57,11 +57,12 @@ public final class PaginationStateBuilder<
      * @param elementConsumer The element consumer.
      * @return This pagination state builder.
      */
+    @SuppressWarnings("unchecked")
     public PaginationStateBuilder<Context, Builder, V> elementFactory(
             @NotNull PaginationValueConsumer<Context, Builder, V> elementConsumer) {
-        this.elementFactory = (context, index, slot, value) -> {
-            @SuppressWarnings("unchecked")
-            Builder builder = (Builder) root.getElementFactory().createComponentBuilder(context);
+        this.elementFactory = (pagination, index, slot, value) -> {
+            Context context = (Context) pagination.getRoot();
+            Builder builder = (Builder) root.getElementFactory().createComponentBuilder(pagination);
             builder.withSlot(slot).withExternallyManaged(true);
             elementConsumer.accept(context, builder, index, value);
             return builder;
@@ -107,6 +108,7 @@ public final class PaginationStateBuilder<
      * @return A new {@link Pagination} state.
      * @throws IllegalStateException If the element factory wasn't set.
      */
+    @SuppressWarnings("unchecked")
     public State<Pagination> build() {
         if (elementFactory == null)
             throw new IllegalStateException(String.format(
@@ -128,7 +130,7 @@ public final class PaginationStateBuilder<
         return layoutTarget;
     }
 
-    PaginationElementFactory<Context, V> getElementFactory() {
+    PaginationElementFactory<V> getElementFactory() {
         return elementFactory;
     }
 

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -754,14 +754,14 @@ public abstract class PlatformView<
     final <V> State<Pagination> createPaginationState(@NotNull PaginationStateBuilder<TContext, TItem, V> builder) {
         requireNotInitialized();
         final long id = State.next();
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({"unchecked", "rawtypes"})
         final StateValueFactory factory = (host, state) -> new PaginationImpl(
                 state,
                 (IFContext) host,
                 builder.getLayoutTarget(),
                 builder.getSourceProvider(),
-                (PaginationElementFactory<IFContext, Object>) builder.getElementFactory(),
-                (BiConsumer<IFContext, Pagination>) builder.getPageSwitchHandler(),
+                (PaginationElementFactory) builder.getElementFactory(),
+                (BiConsumer) builder.getPageSwitchHandler(),
                 builder.isAsync(),
                 builder.isComputed());
         final State<Pagination> state = new PaginationState(id, factory);

--- a/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
+++ b/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
@@ -26,12 +26,12 @@ public class FakeComponent implements Component, InteractionHandler {
         this.position = position;
     }
 
-	@Override
-	public String getKey() {
-		return null;
-	}
+    @Override
+    public String getKey() {
+        return null;
+    }
 
-	@Override
+    @Override
     public @NotNull VirtualView getRoot() {
         return root;
     }

--- a/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
+++ b/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
@@ -26,7 +26,12 @@ public class FakeComponent implements Component, InteractionHandler {
         this.position = position;
     }
 
-    @Override
+	@Override
+	public String getKey() {
+		return null;
+	}
+
+	@Override
     public @NotNull VirtualView getRoot() {
         return root;
     }


### PR DESCRIPTION
Now Pagination component uses context-centralized rendering mechanism that allows Pagination items use `displayIf` and `watch` as regular components. Also `getRoot()` of paginated items was fixed and now returns `Pagination` instead of IFContext.

#465 fixed issues related to regular components with `displayIf` not working with paginated items, this PR resolves: paginated items with `displayIf` not working with regular components with `displayIf`.

Now, this code works fine:

https://github.com/DevNatan/inventory-framework/assets/24600258/85ede378-5541-488f-bd37-7f229157252d

For now displayIf in paginated items do not affects reordering

```java
MutableState<Boolean> showOnlyClockState = mutableState(true);

State<Pagination> paginationState = paginationState(
    IntStream.range(0, 5).boxed().collect(Collectors.toList()),
    (context, builder, index, value) -> {
        builder.withItem(item)
            .displayIf(ctx -> !showClockState.get(ctx))
            .watch(showClockState)
            .onClick(click -> {
                // Enables clock state - will show only the clock
                showOnlyClockState.set(true, click);
            });
    };
);


@Override
public void onFirstRender(@NotNull RenderContext render) {
    render.firstSlot(new ItemStack(Material.CLOCK))
       .displayIf(showClockState::get)
       .watch(showClockState)
       .onClick(click -> {
           // Disables clock state - will show only pagination
           showOnlyClockState.set(false, click);
       });
}
```