### PR TITLE
Call onResume on context back and allow forceUpdate

### DIFF
--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Pagination.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Pagination.java
@@ -204,6 +204,16 @@ public interface Pagination extends ComponentComposition, StateValue {
     boolean isLoading();
 
     /**
+     * Forces the pagination to update everything internally ignoring everything, including
+     * {@link #isLazy() lazy} data source to be computed again.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     */
+    @ApiStatus.Experimental
+    void forceUpdate();
+
+    /**
      * Gets all elements in a given page index based of the specified source.
      *
      * @param index The page index.

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -44,6 +44,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
     private boolean pageWasChanged;
     private boolean initialized;
     private int pagesCount;
+    private boolean forceUpdated;
 
     // Number of elements that each page can have. -1 means uninitialized.
     private int pageSize = -1;
@@ -107,7 +108,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
          */
         final boolean reuseLazy = isLazy() && initialized;
 
-        if ((isStatic() || reuseLazy) && !isComputed()) {
+        if ((isStatic() || reuseLazy) && !isComputed() && !forceUpdated) {
             // For unknown reasons already initialized but source is null, external modification?
             if (initialized && currSource == null)
                 throw new IllegalStateException("User provided pagination source cannot be null");
@@ -359,7 +360,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         final IFRenderContext renderContext = context.getParent();
 
         // If page was changed all components will be removed, so don't trigger update on them
-        if (pageWasChanged) {
+        if (forceUpdated || pageWasChanged) {
             getInternalComponents().forEach(child -> child.clear(renderContext));
             components = new ArrayList<>();
             getInternalComponents().clear();
@@ -570,7 +571,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
             if (child.getInteractionHandler() == null || !child.isVisible()) {
                 continue;
             }
-            ;
+
             if (child.isContainedWithin(context.getClickedSlot())) {
                 child.getInteractionHandler().clicked(component, context);
                 break;
@@ -591,6 +592,13 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
     @Override
     public void update() {
         ((IFContext) getRoot()).updateComponent(this);
+    }
+
+    @Override
+    public void forceUpdate() {
+        forceUpdated = true;
+        update();
+        forceUpdated = false;
     }
 
     @Override

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -168,7 +168,6 @@ public abstract class PlatformView<
     @ApiStatus.Internal
     public final void back(@NotNull Viewer viewer) {
         final IFRenderContext active = viewer.getActiveContext();
-        System.out.println("active = " + active);
         final IFRenderContext target = viewer.getPreviousContext();
         viewer.unsetPreviousContext();
         viewer.setTransitioning(true);
@@ -180,7 +179,6 @@ public abstract class PlatformView<
             final PlatformView root = (PlatformView) target.getRoot();
             if (!root.hasContext(target.getId())) root.addContext(target);
 
-            System.out.println("target = " + target);
             root.renderContext(target);
         }
         viewer.setTransitioning(false);

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -167,6 +167,8 @@ public abstract class PlatformView<
     @SuppressWarnings({"rawtypes", "unchecked"})
     @ApiStatus.Internal
     public final void back(@NotNull Viewer viewer) {
+        final IFRenderContext active = viewer.getActiveContext();
+        System.out.println("active = " + active);
         final IFRenderContext target = viewer.getPreviousContext();
         viewer.unsetPreviousContext();
         viewer.setTransitioning(true);
@@ -178,9 +180,11 @@ public abstract class PlatformView<
             final PlatformView root = (PlatformView) target.getRoot();
             if (!root.hasContext(target.getId())) root.addContext(target);
 
+            System.out.println("target = " + target);
             root.renderContext(target);
         }
         viewer.setTransitioning(false);
+        ((PlatformView) target.getRoot()).onResume(active, target);
     }
 
     private void setupNavigateTo(@NotNull Viewer viewer, @NotNull IFRenderContext origin) {


### PR DESCRIPTION
Force update allows developer to update an component ignoring any internal restriction.
onResume is called when `context.back()` is used