### PR TITLE
Pagination builder as component builder

### DIFF
--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/DefaultComponentBuilder.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/DefaultComponentBuilder.java
@@ -12,8 +12,7 @@ import me.devnatan.inventoryframework.state.State;
 import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("unchecked")
-abstract class DefaultComponentBuilder<S extends ComponentBuilder<S, C>, C extends IFContext>
-        implements ComponentBuilder<S, C> {
+class DefaultComponentBuilder<S extends ComponentBuilder<S, C>, C extends IFContext> implements ComponentBuilder<S, C> {
 
     protected String referenceKey;
     protected Map<String, Object> data;
@@ -21,6 +20,8 @@ abstract class DefaultComponentBuilder<S extends ComponentBuilder<S, C>, C exten
     protected Set<State<?>> watchingStates;
     protected boolean isManagedExternally;
     protected Predicate<C> displayCondition;
+
+    protected DefaultComponentBuilder() {}
 
     protected DefaultComponentBuilder(
             String referenceKey,
@@ -31,6 +32,7 @@ abstract class DefaultComponentBuilder<S extends ComponentBuilder<S, C>, C exten
             Set<State<?>> watchingStates,
             boolean isManagedExternally,
             Predicate<C> displayCondition) {
+        this();
         this.referenceKey = referenceKey;
         this.data = data;
         this.cancelOnClick = cancelOnClick;
@@ -119,5 +121,10 @@ abstract class DefaultComponentBuilder<S extends ComponentBuilder<S, C>, C exten
     @Override
     public S hideIf(BooleanSupplier condition) {
         return displayIf(condition == null ? null : () -> !condition.getAsBoolean());
+    }
+
+    @Override
+    public S copy() {
+        throw new UnsupportedOperationException("Copy is not supported in this component builder.");
     }
 }

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PaginationBuilder.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PaginationBuilder.java
@@ -8,7 +8,7 @@ import me.devnatan.inventoryframework.state.State;
 import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("rawtypes")
-public final class PaginationStateBuilder<
+public final class PaginationBuilder<
         Context extends IFContext, Builder extends ItemComponentBuilder<Builder, Context> & ComponentFactory, V> {
 
     private final PlatformView root;
@@ -18,11 +18,11 @@ public final class PaginationStateBuilder<
     private BiConsumer<Context, Pagination> pageSwitchHandler;
     private final boolean async, computed;
 
-    PaginationStateBuilder(PlatformView root, Object sourceProvider) {
+    PaginationBuilder(PlatformView root, Object sourceProvider) {
         this(root, sourceProvider, false, false);
     }
 
-    PaginationStateBuilder(PlatformView root, Object sourceProvider, boolean async, boolean computed) {
+    PaginationBuilder(PlatformView root, Object sourceProvider, boolean async, boolean computed) {
         this.root = root;
         this.sourceProvider = sourceProvider;
         this.async = async;
@@ -41,7 +41,7 @@ public final class PaginationStateBuilder<
      * @param itemFactory The item factory.
      * @return This pagination state builder.
      */
-    public PaginationStateBuilder<Context, Builder, V> itemFactory(@NotNull BiConsumer<Builder, V> itemFactory) {
+    public PaginationBuilder<Context, Builder, V> itemFactory(@NotNull BiConsumer<Builder, V> itemFactory) {
         return elementFactory(((context, builder, index, value) -> itemFactory.accept(builder, value)));
     }
 
@@ -58,7 +58,7 @@ public final class PaginationStateBuilder<
      * @return This pagination state builder.
      */
     @SuppressWarnings("unchecked")
-    public PaginationStateBuilder<Context, Builder, V> elementFactory(
+    public PaginationBuilder<Context, Builder, V> elementFactory(
             @NotNull PaginationValueConsumer<Context, Builder, V> elementConsumer) {
         this.elementFactory = (pagination, index, slot, value) -> {
             Context context = (Context) pagination.getRoot();
@@ -82,7 +82,7 @@ public final class PaginationStateBuilder<
      * @param layoutTarget The target layout character.
      * @return This pagination state builder.
      */
-    public PaginationStateBuilder<Context, Builder, V> layoutTarget(char layoutTarget) {
+    public PaginationBuilder<Context, Builder, V> layoutTarget(char layoutTarget) {
         this.layoutTarget = layoutTarget;
         return this;
     }
@@ -96,7 +96,7 @@ public final class PaginationStateBuilder<
      * @param pageSwitchHandler The page switch handler.
      * @return This pagination state builder.
      */
-    public PaginationStateBuilder<Context, Builder, V> onPageSwitch(
+    public PaginationBuilder<Context, Builder, V> onPageSwitch(
             @NotNull BiConsumer<Context, Pagination> pageSwitchHandler) {
         this.pageSwitchHandler = pageSwitchHandler;
         return this;

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -680,9 +680,9 @@ public abstract class PlatformView<
      * @param <T>            The pagination data type.
      * @return A new pagination state builder.
      */
-    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildPaginationState(
+    protected final <T> PaginationBuilder<TContext, TItem, T> buildPaginationState(
             @NotNull List<? super T> sourceProvider) {
-        return new PaginationStateBuilder<>(this, sourceProvider);
+        return new PaginationBuilder<>(this, sourceProvider);
     }
 
     /**
@@ -692,9 +692,9 @@ public abstract class PlatformView<
      * @param <T>            The pagination data type.
      * @return A new pagination state builder.
      */
-    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildComputedPaginationState(
+    protected final <T> PaginationBuilder<TContext, TItem, T> buildComputedPaginationState(
             @NotNull Function<TContext, List<? super T>> sourceProvider) {
-        return new PaginationStateBuilder<>(this, sourceProvider, false, true);
+        return new PaginationBuilder<>(this, sourceProvider, false, true);
     }
 
     /**
@@ -708,9 +708,9 @@ public abstract class PlatformView<
      * @return A new pagination state builder.
      */
     @ApiStatus.Experimental
-    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildComputedAsyncPaginationState(
+    protected final <T> PaginationBuilder<TContext, TItem, T> buildComputedAsyncPaginationState(
             @NotNull Function<TContext, CompletableFuture<List<T>>> sourceProvider) {
-        return new PaginationStateBuilder<>(this, sourceProvider, true, true);
+        return new PaginationBuilder<>(this, sourceProvider, true, true);
     }
 
     /**
@@ -720,9 +720,9 @@ public abstract class PlatformView<
      * @param <T>            The pagination data type.
      * @return A new pagination state builder.
      */
-    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildLazyPaginationState(
+    protected final <T> PaginationBuilder<TContext, TItem, T> buildLazyPaginationState(
             @NotNull Supplier<List<? super T>> sourceProvider) {
-        return new PaginationStateBuilder<>(this, sourceProvider, false, false);
+        return new PaginationBuilder<>(this, sourceProvider, false, false);
     }
 
     /**
@@ -732,9 +732,9 @@ public abstract class PlatformView<
      * @param <T>            The pagination data type.
      * @return A new pagination state builder.
      */
-    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildLazyPaginationState(
+    protected final <T> PaginationBuilder<TContext, TItem, T> buildLazyPaginationState(
             @NotNull Function<TContext, List<? super T>> sourceProvider) {
-        return new PaginationStateBuilder<>(this, sourceProvider, false, false);
+        return new PaginationBuilder<>(this, sourceProvider, false, false);
     }
 
     /**
@@ -748,12 +748,12 @@ public abstract class PlatformView<
      * @return A new pagination state builder.
      */
     @ApiStatus.Experimental
-    protected final <T> PaginationStateBuilder<TContext, TItem, T> buildLazyAsyncPaginationState(
+    protected final <T> PaginationBuilder<TContext, TItem, T> buildLazyAsyncPaginationState(
             @NotNull Function<TContext, CompletableFuture<List<T>>> sourceProvider) {
-        return new PaginationStateBuilder<>(this, sourceProvider, true, false);
+        return new PaginationBuilder<>(this, sourceProvider, true, false);
     }
 
-    final <V> State<Pagination> createPaginationState(@NotNull PaginationStateBuilder<TContext, TItem, V> builder) {
+    final <V> State<Pagination> createPaginationState(@NotNull PaginationBuilder<TContext, TItem, V> builder) {
         requireNotInitialized();
         final long id = State.next();
         @SuppressWarnings({"unchecked", "rawtypes"})

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -7,7 +7,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import me.devnatan.inventoryframework.component.*;
@@ -753,19 +752,15 @@ public abstract class PlatformView<
         return new PaginationBuilder<>(this, sourceProvider, true, false);
     }
 
-    final <V> State<Pagination> createPaginationState(@NotNull PaginationBuilder<TContext, TItem, V> builder) {
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    public final <V> State<Pagination> createPaginationState(@NotNull PaginationBuilder<TContext, TItem, V> builder) {
         requireNotInitialized();
         final long id = State.next();
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        final StateValueFactory factory = (host, state) -> new PaginationImpl(
-                state,
-                (IFContext) host,
-                builder.getLayoutTarget(),
-                builder.getSourceProvider(),
-                (PaginationElementFactory) builder.getElementFactory(),
-                (BiConsumer) builder.getPageSwitchHandler(),
-                builder.isAsync(),
-                builder.isComputed());
+        final StateValueFactory factory = builder::toPagination;
         final State<Pagination> state = new PaginationState(id, factory);
         stateRegistry.registerState(state, this);
 

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/component/PaginationBuilder.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/component/PaginationBuilder.java
@@ -26,7 +26,8 @@ public final class PaginationBuilder<
     }
 
     PaginationBuilder(PlatformView root, Object sourceProvider, boolean async, boolean computed) {
-        this.root = root;
+		super();
+		this.root = root;
         this.sourceProvider = sourceProvider;
         this.async = async;
         this.computed = computed;

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/component/PaginationBuilder.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/component/PaginationBuilder.java
@@ -1,7 +1,8 @@
-package me.devnatan.inventoryframework;
+package me.devnatan.inventoryframework.component;
 
 import java.util.function.BiConsumer;
-import me.devnatan.inventoryframework.component.*;
+
+import me.devnatan.inventoryframework.PlatformView;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.internal.LayoutSlot;
 import me.devnatan.inventoryframework.state.State;
@@ -9,7 +10,9 @@ import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("rawtypes")
 public final class PaginationBuilder<
-        Context extends IFContext, Builder extends ItemComponentBuilder<Builder, Context> & ComponentFactory, V> {
+	Context extends IFContext,
+	Builder extends ItemComponentBuilder<Builder, Context> & ComponentFactory,
+	V> extends DefaultComponentBuilder<PaginationBuilder<Context, Builder, V>, Context> {
 
     private final PlatformView root;
     private final Object sourceProvider;

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/component/PaginationBuilder.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/component/PaginationBuilder.java
@@ -1,18 +1,18 @@
 package me.devnatan.inventoryframework.component;
 
 import java.util.function.BiConsumer;
-
 import me.devnatan.inventoryframework.PlatformView;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.internal.LayoutSlot;
 import me.devnatan.inventoryframework.state.State;
+import me.devnatan.inventoryframework.state.StateValueHost;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("rawtypes")
 public final class PaginationBuilder<
-	Context extends IFContext,
-	Builder extends ItemComponentBuilder<Builder, Context> & ComponentFactory,
-	V> extends DefaultComponentBuilder<PaginationBuilder<Context, Builder, V>, Context> {
+                Context extends IFContext, Builder extends ItemComponentBuilder<Builder, Context> & ComponentFactory, V>
+        extends DefaultComponentBuilder<PaginationBuilder<Context, Builder, V>, Context> {
 
     private final PlatformView root;
     private final Object sourceProvider;
@@ -21,13 +21,23 @@ public final class PaginationBuilder<
     private BiConsumer<Context, Pagination> pageSwitchHandler;
     private final boolean async, computed;
 
-    PaginationBuilder(PlatformView root, Object sourceProvider) {
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    public PaginationBuilder(PlatformView root, Object sourceProvider) {
         this(root, sourceProvider, false, false);
     }
 
-    PaginationBuilder(PlatformView root, Object sourceProvider, boolean async, boolean computed) {
-		super();
-		this.root = root;
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    public PaginationBuilder(PlatformView root, Object sourceProvider, boolean async, boolean computed) {
+        super();
+        this.root = root;
         this.sourceProvider = sourceProvider;
         this.async = async;
         this.computed = computed;
@@ -122,31 +132,21 @@ public final class PaginationBuilder<
         return root.createPaginationState(this);
     }
 
-    PlatformView getRoot() {
-        return root;
-    }
-
-    Object getSourceProvider() {
-        return sourceProvider;
-    }
-
-    char getLayoutTarget() {
-        return layoutTarget;
-    }
-
-    PaginationElementFactory<V> getElementFactory() {
-        return elementFactory;
-    }
-
-    BiConsumer<Context, Pagination> getPageSwitchHandler() {
-        return pageSwitchHandler;
-    }
-
-    boolean isAsync() {
-        return async;
-    }
-
-    boolean isComputed() {
-        return computed;
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    @SuppressWarnings("unchecked")
+    public Pagination toPagination(StateValueHost host, State<?> state) {
+        return new PaginationImpl(
+                state,
+                (IFContext) host,
+                layoutTarget,
+                sourceProvider,
+                (PaginationElementFactory) elementFactory,
+                (BiConsumer) pageSwitchHandler,
+                async,
+                computed);
     }
 }


### PR DESCRIPTION
Since Pagination is a Component its builder should be a ComponentBuilder as well. With this change will be possible to do everything that is done with item components (`slot`, `layoutSlot`, etc.), with pagination too like use `displayIf` to show/hide pagination entirely based on a condition.

What's changed:
* PaginationStateBuilder renamed to PaginationBuilder
* PaginationBuilder now extends DefaultComponentBuilder
* PaginationBuilder moved to "me.devnatan.inventoryframework.component"
