### PR TITLE
Refs API

### DIFF
--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/Ref.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/Ref.java
@@ -29,5 +29,5 @@ public interface Ref<E> {
      * this library. No compatibility guarantees are provided. </i></b>
      */
     @ApiStatus.Internal
-    void assign(E value);
+    void assign(Object value);
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/Ref.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/Ref.java
@@ -15,12 +15,12 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Experimental
 public interface Ref<E> {
 
-	/**
-	 * Returns the value hold by this reference.
-	 *
-	 * @throws UnassignedReferenceException If reference wasn't assigned to any element.
-	 * @return The value that this reference holds.
-	 */
-	@NotNull
-	E value(@NotNull IFContext context);
+    /**
+     * Returns the value hold by this reference.
+     *
+     * @throws UnassignedReferenceException If reference wasn't assigned to any element.
+     * @return The value that this reference holds.
+     */
+    @NotNull
+    E value(@NotNull IFContext context);
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/Ref.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/Ref.java
@@ -1,0 +1,26 @@
+package me.devnatan.inventoryframework;
+
+import me.devnatan.inventoryframework.context.IFContext;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Ref's hold a reference of any element inside a {@link me.devnatan.inventoryframework.context.IFContext}.
+ * <p>
+ * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+ * such API may be changed or may be removed completely in any further release. </i></b>
+ *
+ * @param <E> Type of the value that this ref is holding.
+ */
+@ApiStatus.Experimental
+public interface Ref<E> {
+
+	/**
+	 * Returns the value hold by this reference.
+	 *
+	 * @throws UnassignedReferenceException If reference wasn't assigned to any element.
+	 * @return The value that this reference holds.
+	 */
+	@NotNull
+	E value(@NotNull IFContext context);
+}

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/Ref.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/Ref.java
@@ -23,4 +23,11 @@ public interface Ref<E> {
      */
     @NotNull
     E value(@NotNull IFContext context);
+
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    void assign(E value);
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/UnassignedReferenceException.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/UnassignedReferenceException.java
@@ -1,4 +1,3 @@
 package me.devnatan.inventoryframework;
 
-public class UnassignedReferenceException extends InventoryFrameworkException {
-}
+public class UnassignedReferenceException extends InventoryFrameworkException {}

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/UnassignedReferenceException.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/UnassignedReferenceException.java
@@ -1,0 +1,4 @@
+package me.devnatan.inventoryframework;
+
+public class UnassignedReferenceException extends InventoryFrameworkException {
+}

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Component.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Component.java
@@ -159,4 +159,22 @@ public interface Component extends VirtualView {
      */
     @ApiStatus.Experimental
     void forceUpdate();
+
+    /**
+     * Shows this component.
+     * <p>
+     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     */
+    @ApiStatus.Experimental
+    void show();
+
+    /**
+     * Hides this component.
+     * <p>
+     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     */
+    @ApiStatus.Experimental
+    void hide();
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Component.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/Component.java
@@ -1,6 +1,7 @@
 package me.devnatan.inventoryframework.component;
 
 import java.util.Set;
+import me.devnatan.inventoryframework.Ref;
 import me.devnatan.inventoryframework.VirtualView;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.context.IFSlotRenderContext;
@@ -140,4 +141,22 @@ public interface Component extends VirtualView {
 
         return other.isContainedWithin(component.getPosition());
     }
+
+    /**
+     * Returns the reference assigned to this component.
+     * <p>
+     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     */
+    @ApiStatus.Experimental
+    Ref<Component> getReference();
+
+    /**
+     * Forces this component to be updated.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     */
+    @ApiStatus.Experimental
+    void forceUpdate();
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ComponentBuilder.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ComponentBuilder.java
@@ -2,6 +2,7 @@ package me.devnatan.inventoryframework.component;
 
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
+import me.devnatan.inventoryframework.Ref;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.state.State;
 import org.jetbrains.annotations.ApiStatus;
@@ -15,19 +16,13 @@ import org.jetbrains.annotations.NotNull;
 public interface ComponentBuilder<S extends ComponentBuilder<S, C>, C extends IFContext> {
 
     /**
-     * Defines the reference key for this component.
-     * <p>
-     * Reference keys can be used to get an instance of a component that you can later reference
-     * this component in an unknown handler in your code and update this component manually, for
-     * example, if necessary.
-     * <pre>{@code
-     * IFSlotContext context = context.ref("my-component");
-     * }</pre>
+     * Assigns {@link Ref a reference} to this component.
      *
-     * @param key The component reference key.
+     * @param reference Component reference key.
      * @return This component builder.
+     * @see <a href="https://github.com/DevNatan/inventory-framework/wiki/refs-api">Refs API on Wiki</a>
      */
-    S referencedBy(@NotNull String key);
+    S referencedBy(@NotNull Ref<Component> reference);
 
     /**
      * Adds a new user-defined property to this component.

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
@@ -178,7 +178,7 @@ public class ItemComponent implements Component, InteractionHandler {
         if (context.isCancelled()) return;
 
         // Static item with no `displayIf` must not even reach the update handler
-        if (displayCondition == null && getRenderHandler() == null) return;
+        if (!context.isForceUpdate() && displayCondition == null && getRenderHandler() == null) return;
 
         if (getUpdateHandler() != null) {
             getUpdateHandler().accept(context);
@@ -199,7 +199,7 @@ public class ItemComponent implements Component, InteractionHandler {
             throw new IllegalStateException(
                     "This component is externally managed by another component and cannot be updated directly");
 
-        if (root instanceof IFContext) ((IFContext) root).updateComponent(this);
+        if (root instanceof IFContext) ((IFContext) root).updateComponent(this, false);
     }
 
     @Override
@@ -237,7 +237,21 @@ public class ItemComponent implements Component, InteractionHandler {
 
     @Override
     public void forceUpdate() {
-        update();
+        if (root instanceof IFContext) ((IFContext) root).updateComponent(this, true);
+    }
+
+    @Override
+    public void hide() {
+        setVisible(false);
+
+        // TODO Change update mechanism to allow in-ComponentComposition child to be hidden
+        clear((IFContext) getRoot());
+    }
+
+    @Override
+    public void show() {
+        setVisible(true);
+        forceUpdate();
     }
 
     @Override

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import me.devnatan.inventoryframework.InventoryFrameworkException;
+import me.devnatan.inventoryframework.Ref;
 import me.devnatan.inventoryframework.VirtualView;
 import me.devnatan.inventoryframework.context.*;
 import me.devnatan.inventoryframework.state.State;
@@ -30,6 +31,7 @@ public class ItemComponent implements Component, InteractionHandler {
     private final boolean isManagedExternally;
     private final boolean updateOnClick;
     private boolean isVisible;
+    private final Ref<Component> reference;
 
     public ItemComponent(
             VirtualView root,
@@ -44,7 +46,8 @@ public class ItemComponent implements Component, InteractionHandler {
             Set<State<?>> watching,
             boolean isManagedExternally,
             boolean updateOnClick,
-            boolean isVisible) {
+            boolean isVisible,
+            Ref<Component> reference) {
         this.root = root;
         this.position = position;
         this.stack = stack;
@@ -58,6 +61,7 @@ public class ItemComponent implements Component, InteractionHandler {
         this.isManagedExternally = isManagedExternally;
         this.updateOnClick = updateOnClick;
         this.isVisible = isVisible;
+        this.reference = reference;
     }
 
     @Override
@@ -224,6 +228,16 @@ public class ItemComponent implements Component, InteractionHandler {
     @Override
     public boolean isManagedExternally() {
         return isManagedExternally;
+    }
+
+    @Override
+    public Ref<Component> getReference() {
+        return reference;
+    }
+
+    @Override
+    public void forceUpdate() {
+        update();
     }
 
     @Override

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFContext.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFContext.java
@@ -150,9 +150,10 @@ public interface IFContext extends VirtualView, StateValueHost, ComponentContain
      * this library. No compatibility guarantees are provided.</i></b>
      *
      * @param component The component to be updated.
+     * @param force If update should be forced.
      */
     @ApiStatus.Internal
-    void updateComponent(@NotNull Component component);
+    void updateComponent(@NotNull Component component, boolean force);
 
     /**
      * Updates all components for all viewers in this context.

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFSlotRenderContext.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFSlotRenderContext.java
@@ -46,4 +46,18 @@ public interface IFSlotRenderContext extends IFSlotContext, IFConfinedContext {
      */
     @ApiStatus.Internal
     void setChanged(boolean changed);
+
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    boolean isForceUpdate();
+
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    void setForceUpdate(boolean forceUpdate);
 }

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/MultiRefsImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/MultiRefsImpl.java
@@ -1,0 +1,29 @@
+package me.devnatan.inventoryframework;
+
+import java.util.ArrayList;
+import java.util.List;
+import me.devnatan.inventoryframework.context.IFContext;
+import org.jetbrains.annotations.NotNull;
+
+final class MultiRefsImpl<E> implements Ref<List<E>> {
+
+    private final List<E> assignments = new ArrayList<>();
+
+    @Override
+    public @NotNull List<E> value(@NotNull IFContext context) {
+        return assignments;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void assign(Object value) {
+        synchronized (assignments) {
+            try {
+                assignments.add((E) value);
+            } catch (final ClassCastException exception) {
+                throw new IllegalArgumentException(
+                        "Multi-Refs assignment type must be the same as type parameter type", exception);
+            }
+        }
+    }
+}

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/RefImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/RefImpl.java
@@ -18,7 +18,7 @@ final class RefImpl<E> implements Ref<E> {
     }
 
     @Override
-    public void assign(E value) {
+    public void assign(Object value) {
         if (assignment != UNASSIGNED_VALUE) throw new IllegalStateException("Reference cannot be reassigned");
 
         this.assignment = value;

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/RefImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/RefImpl.java
@@ -1,0 +1,26 @@
+package me.devnatan.inventoryframework;
+
+import me.devnatan.inventoryframework.context.IFContext;
+import org.jetbrains.annotations.NotNull;
+
+final class RefImpl<E> implements Ref<E> {
+
+    private static final Object UNASSIGNED_VALUE = new Object();
+
+    private Object assignment = UNASSIGNED_VALUE;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public @NotNull E value(@NotNull IFContext context) {
+        if (assignment == UNASSIGNED_VALUE) throw new UnassignedReferenceException();
+
+        return (E) assignment;
+    }
+
+    @Override
+    public void assign(E value) {
+        if (assignment != UNASSIGNED_VALUE) throw new IllegalStateException("Reference cannot be reassigned");
+
+        this.assignment = value;
+    }
+}

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/DefaultComponentBuilder.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/DefaultComponentBuilder.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
+import me.devnatan.inventoryframework.Ref;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.state.State;
 import org.jetbrains.annotations.NotNull;
@@ -15,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
 abstract class DefaultComponentBuilder<S extends ComponentBuilder<S, C>, C extends IFContext>
         implements ComponentBuilder<S, C> {
 
-    protected String referenceKey;
+    protected Ref<Component> reference;
     protected Map<String, Object> data;
     protected boolean cancelOnClick, closeOnClick, updateOnClick;
     protected Set<State<?>> watchingStates;
@@ -23,7 +24,7 @@ abstract class DefaultComponentBuilder<S extends ComponentBuilder<S, C>, C exten
     protected Predicate<C> displayCondition;
 
     protected DefaultComponentBuilder(
-            String referenceKey,
+            Ref<Component> reference,
             Map<String, Object> data,
             boolean cancelOnClick,
             boolean closeOnClick,
@@ -31,7 +32,7 @@ abstract class DefaultComponentBuilder<S extends ComponentBuilder<S, C>, C exten
             Set<State<?>> watchingStates,
             boolean isManagedExternally,
             Predicate<C> displayCondition) {
-        this.referenceKey = referenceKey;
+        this.reference = reference;
         this.data = data;
         this.cancelOnClick = cancelOnClick;
         this.closeOnClick = closeOnClick;
@@ -42,8 +43,8 @@ abstract class DefaultComponentBuilder<S extends ComponentBuilder<S, C>, C exten
     }
 
     @Override
-    public S referencedBy(@NotNull String key) {
-        this.referenceKey = key;
+    public S referencedBy(@NotNull Ref<Component> reference) {
+        this.reference = reference;
         return (S) this;
     }
 

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import me.devnatan.inventoryframework.Ref;
 import me.devnatan.inventoryframework.ViewContainer;
 import me.devnatan.inventoryframework.VirtualView;
 import me.devnatan.inventoryframework.context.*;
@@ -659,6 +660,11 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         forceUpdated = true;
         update();
         forceUpdated = false;
+    }
+
+    @Override
+    public Ref<Component> getReference() {
+        return null;
     }
 
     @Override

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -551,7 +551,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
 
         if (pageSwitchHandler != null) pageSwitchHandler.accept(host, this);
 
-        host.updateComponent(this);
+        host.updateComponent(this, false);
     }
 
     @Override
@@ -652,7 +652,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
 
     @Override
     public void update() {
-        ((IFContext) getRoot()).updateComponent(this);
+        ((IFContext) getRoot()).updateComponent(this, false);
     }
 
     @Override
@@ -660,6 +660,18 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
         forceUpdated = true;
         update();
         forceUpdated = false;
+    }
+
+    @Override
+    public void show() {
+        setVisible(true);
+        update();
+    }
+
+    @Override
+    public void hide() {
+        setVisible(false);
+        update();
     }
 
     @Override

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/context/AbstractIFContext.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/context/AbstractIFContext.java
@@ -91,17 +91,17 @@ abstract class AbstractIFContext extends DefaultStateValueHost implements IFCont
         }
     }
 
-    private IFSlotRenderContext createSlotRenderContext(@NotNull Component component) {
+    private IFSlotRenderContext createSlotRenderContext(@NotNull Component component, boolean force) {
         if (!(this instanceof IFRenderContext))
             throw new InventoryFrameworkException("Slot render context cannot be created from non-render parent");
 
         final IFRenderContext renderContext = (IFRenderContext) this;
-        return getRoot()
+        final IFSlotRenderContext slotRender = getRoot()
                 .getElementFactory()
                 .createSlotRenderContext(component.getPosition(), renderContext, renderContext.getViewer());
+        slotRender.setForceUpdate(force);
+        return slotRender;
     }
-
-    int modCount = 0;
 
     @Override
     public void renderComponent(@NotNull Component component) {
@@ -111,15 +111,6 @@ abstract class AbstractIFContext extends DefaultStateValueHost implements IFCont
             final Optional<Component> overlapOptional = getOverlappingComponentToRender(this, component);
             if (overlapOptional.isPresent()) {
                 Component overlap = overlapOptional.get();
-
-                // ComponentComposition can have a single child overlapping this component so,
-                // to prevent re-render of the entire component we just seek for this single child
-                // and render it individually
-                //				while (overlap instanceof ComponentComposition) {
-                //					final ComponentComposition composition = (ComponentComposition) overlap;
-                //					overlap = getOverlappingComponent(composition, overlap).orElse(overlap);
-                //				}
-
                 renderComponent(overlap);
 
                 if (overlap.isVisible()) return;
@@ -128,7 +119,7 @@ abstract class AbstractIFContext extends DefaultStateValueHost implements IFCont
             component.clear(this);
             return;
         }
-        component.render(createSlotRenderContext(component));
+        component.render(createSlotRenderContext(component, false));
     }
 
     private Optional<Component> getOverlappingComponentToRender(ComponentContainer container, Component subject) {
@@ -164,8 +155,8 @@ abstract class AbstractIFContext extends DefaultStateValueHost implements IFCont
     }
 
     @Override
-    public void updateComponent(@NotNull Component component) {
-        component.updated(createSlotRenderContext(component));
+    public void updateComponent(@NotNull Component component, boolean force) {
+        component.updated(createSlotRenderContext(component, force));
     }
 
     @Override

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/UpdateInterceptor.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/UpdateInterceptor.java
@@ -24,7 +24,7 @@ public final class UpdateInterceptor implements PipelineInterceptor<VirtualView>
                 continue;
             }
 
-            context.updateComponent(component);
+            context.updateComponent(component, false);
         }
     }
 }

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/component/BukkitItemComponentBuilder.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/component/BukkitItemComponentBuilder.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import me.devnatan.inventoryframework.Ref;
 import me.devnatan.inventoryframework.ViewContainer;
 import me.devnatan.inventoryframework.VirtualView;
 import me.devnatan.inventoryframework.context.*;
@@ -51,7 +52,7 @@ public final class BukkitItemComponentBuilder extends DefaultComponentBuilder<Bu
             Consumer<? super IFSlotRenderContext> renderHandler,
             Consumer<? super IFSlotClickContext> clickHandler,
             Consumer<? super IFSlotContext> updateHandler,
-            String referenceKey,
+            Ref<Component> reference,
             Map<String, Object> data,
             boolean cancelOnClick,
             boolean closeOnClick,
@@ -60,7 +61,7 @@ public final class BukkitItemComponentBuilder extends DefaultComponentBuilder<Bu
             boolean isManagedExternally,
             Predicate<Context> displayCondition) {
         super(
-                referenceKey,
+                reference,
                 data,
                 cancelOnClick,
                 closeOnClick,
@@ -200,7 +201,8 @@ public final class BukkitItemComponentBuilder extends DefaultComponentBuilder<Bu
                 watchingStates,
                 isManagedExternally,
                 updateOnClick,
-                false);
+                false,
+                reference);
     }
 
     @Override
@@ -212,7 +214,7 @@ public final class BukkitItemComponentBuilder extends DefaultComponentBuilder<Bu
                 renderHandler,
                 clickHandler,
                 updateHandler,
-                referenceKey,
+                reference,
                 data,
                 cancelOnClick,
                 closeOnClick,

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/SlotContext.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/SlotContext.java
@@ -87,8 +87,8 @@ public abstract class SlotContext extends PlatformContext implements IFSlotConte
     }
 
     @Override
-    public final void updateComponent(@NotNull Component component) {
-        getParent().updateComponent(component);
+    public final void updateComponent(@NotNull Component component, boolean force) {
+        getParent().updateComponent(component, force);
     }
 
     @Override

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/SlotRenderContext.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/SlotRenderContext.java
@@ -14,10 +14,10 @@ public class SlotRenderContext extends SlotContext implements IFSlotRenderContex
 
     private final Player player;
     private final Viewer viewer;
-
     private ItemStack item;
     private boolean cancelled;
     private boolean changed;
+    private boolean forceUpdate;
 
     @ApiStatus.Internal
     public SlotRenderContext(int slot, @NotNull IFRenderContext parent, @Nullable Viewer viewer) {
@@ -69,6 +69,16 @@ public class SlotRenderContext extends SlotContext implements IFSlotRenderContex
     @Override
     public final void setChanged(boolean changed) {
         this.changed = changed;
+    }
+
+    @Override
+    public boolean isForceUpdate() {
+        return forceUpdate;
+    }
+
+    @Override
+    public void setForceUpdate(boolean forceUpdate) {
+        this.forceUpdate = forceUpdate;
     }
 
     @Override

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/runtime/InventoryFramework.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/runtime/InventoryFramework.java
@@ -1,8 +1,40 @@
 package me.devnatan.inventoryframework.runtime;
 
+import me.devnatan.inventoryframework.Ref;
+import me.devnatan.inventoryframework.View;
+import me.devnatan.inventoryframework.ViewConfigBuilder;
+import me.devnatan.inventoryframework.ViewFrame;
+import me.devnatan.inventoryframework.component.Component;
+import me.devnatan.inventoryframework.context.RenderContext;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
 
 public final class InventoryFramework extends JavaPlugin {
 
     public static final String LIBRARY_VERSION = "3.0.0-rc.3";
+
+    @Override
+    public void onEnable() {
+        ViewFrame vf = ViewFrame.create(this).enableDebug().with(new A()).register();
+        getServer().getOnlinePlayers().forEach(player -> vf.open(A.class, player));
+    }
+}
+
+class A extends View {
+
+    private final Ref<Component> diamondRef = ref();
+
+    @Override
+    public void onInit(@NotNull ViewConfigBuilder config) {
+        config.title("S");
+    }
+
+    @Override
+    public void onFirstRender(@NotNull RenderContext render) {
+        render.firstSlot(new ItemStack(Material.DIAMOND))
+                .referencedBy(diamondRef)
+                .cancelOnClick();
+    }
 }

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/runtime/InventoryFramework.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/runtime/InventoryFramework.java
@@ -1,40 +1,8 @@
 package me.devnatan.inventoryframework.runtime;
 
-import me.devnatan.inventoryframework.Ref;
-import me.devnatan.inventoryframework.View;
-import me.devnatan.inventoryframework.ViewConfigBuilder;
-import me.devnatan.inventoryframework.ViewFrame;
-import me.devnatan.inventoryframework.component.Component;
-import me.devnatan.inventoryframework.context.RenderContext;
-import org.bukkit.Material;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.jetbrains.annotations.NotNull;
 
 public final class InventoryFramework extends JavaPlugin {
 
     public static final String LIBRARY_VERSION = "3.0.0-rc.3";
-
-    @Override
-    public void onEnable() {
-        ViewFrame vf = ViewFrame.create(this).enableDebug().with(new A()).register();
-        getServer().getOnlinePlayers().forEach(player -> vf.open(A.class, player));
-    }
-}
-
-class A extends View {
-
-    private final Ref<Component> diamondRef = ref();
-
-    @Override
-    public void onInit(@NotNull ViewConfigBuilder config) {
-        config.title("S");
-    }
-
-    @Override
-    public void onFirstRender(@NotNull RenderContext render) {
-        render.firstSlot(new ItemStack(Material.DIAMOND))
-                .referencedBy(diamondRef)
-                .cancelOnClick();
-    }
 }

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -364,7 +364,7 @@ public abstract class PlatformView<
      */
     @ApiStatus.Experimental
     protected final <E> Ref<E> ref() {
-        throw new UnsupportedOperationException("Not implemented yet");
+        return new RefImpl<>();
     }
 
     /**

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -368,7 +368,7 @@ public abstract class PlatformView<
     }
 
     /**
-     * Creates a new empty reference instance that can hold multiple elements.
+     * Creates a new empty reference instance that can hold multiple elements of the same type.
      * <p>
      * <b><i> This API is experimental and is not subject to the general compatibility guarantees
      * such API may be changed or may be removed completely in any further release. </i></b>
@@ -379,7 +379,7 @@ public abstract class PlatformView<
      */
     @ApiStatus.Experimental
     protected final <E> Ref<List<E>> multiRefs() {
-        throw new UnsupportedOperationException("Not implemented yet");
+        return new MultiRefsImpl<>();
     }
 
     /**

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -352,6 +352,21 @@ public abstract class PlatformView<
         return (Iterator<TContext>) getContexts().iterator();
     }
 
+	/**
+	 * Creates a new unassigned reference instance.
+	 * <p>
+	 * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+	 * such API may be changed or may be removed completely in any further release. </i></b>
+	 *
+	 * @return A new unassigned {@link Ref} instance.
+	 * @param <E> Type of the element hold by this reference.
+	 * @see <a href="https://github.com/DevNatan/inventory-framework/wiki/refs-api">Refs API on Wiki</a>
+	 */
+	@ApiStatus.Experimental
+	protected final <E> Ref<E> ref() {
+		throw new UnsupportedOperationException("Not implemented yet");
+	}
+
     /**
      * Creates an immutable state with an initial value.
      *

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -352,35 +352,35 @@ public abstract class PlatformView<
         return (Iterator<TContext>) getContexts().iterator();
     }
 
-	/**
-	 * Creates a new unassigned reference instance.
-	 * <p>
-	 * <b><i> This API is experimental and is not subject to the general compatibility guarantees
-	 * such API may be changed or may be removed completely in any further release. </i></b>
-	 *
-	 * @return A new unassigned {@link Ref} instance.
-	 * @param <E> Type of the element hold by this reference.
-	 * @see <a href="https://github.com/DevNatan/inventory-framework/wiki/refs-api">Refs API on Wiki</a>
-	 */
-	@ApiStatus.Experimental
-	protected final <E> Ref<E> ref() {
-		throw new UnsupportedOperationException("Not implemented yet");
-	}
+    /**
+     * Creates a new unassigned reference instance.
+     * <p>
+     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @return A new unassigned {@link Ref} instance.
+     * @param <E> Type of the element hold by this reference.
+     * @see <a href="https://github.com/DevNatan/inventory-framework/wiki/refs-api">Refs API on Wiki</a>
+     */
+    @ApiStatus.Experimental
+    protected final <E> Ref<E> ref() {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
 
-	/**
-	 * Creates a new empty reference instance that can hold multiple elements.
-	 * <p>
-	 * <b><i> This API is experimental and is not subject to the general compatibility guarantees
-	 * such API may be changed or may be removed completely in any further release. </i></b>
-	 *
-	 * @return A new unassigned {@link Ref} instance.
-	 * @param <E> Type of the element hold by this reference.
-	 * @see <a href="https://github.com/DevNatan/inventory-framework/wiki/refs-api">Refs API on Wiki</a>
-	 */
-	@ApiStatus.Experimental
-	protected final <E> Ref<List<E>> multiRefs() {
-		throw new UnsupportedOperationException("Not implemented yet");
-	}
+    /**
+     * Creates a new empty reference instance that can hold multiple elements.
+     * <p>
+     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @return A new unassigned {@link Ref} instance.
+     * @param <E> Type of the element hold by this reference.
+     * @see <a href="https://github.com/DevNatan/inventory-framework/wiki/refs-api">Refs API on Wiki</a>
+     */
+    @ApiStatus.Experimental
+    protected final <E> Ref<List<E>> multiRefs() {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
 
     /**
      * Creates an immutable state with an initial value.

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -367,6 +367,21 @@ public abstract class PlatformView<
 		throw new UnsupportedOperationException("Not implemented yet");
 	}
 
+	/**
+	 * Creates a new empty reference instance that can hold multiple elements.
+	 * <p>
+	 * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+	 * such API may be changed or may be removed completely in any further release. </i></b>
+	 *
+	 * @return A new unassigned {@link Ref} instance.
+	 * @param <E> Type of the element hold by this reference.
+	 * @see <a href="https://github.com/DevNatan/inventory-framework/wiki/refs-api">Refs API on Wiki</a>
+	 */
+	@ApiStatus.Experimental
+	protected final <E> Ref<List<E>> multiRefs() {
+		throw new UnsupportedOperationException("Not implemented yet");
+	}
+
     /**
      * Creates an immutable state with an initial value.
      *

--- a/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
+++ b/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
@@ -2,6 +2,7 @@ package me.devnatan.inventoryframework.component;
 
 import java.util.Collections;
 import java.util.Set;
+import me.devnatan.inventoryframework.Ref;
 import me.devnatan.inventoryframework.VirtualView;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.context.IFRenderContext;
@@ -97,4 +98,12 @@ public class FakeComponent implements Component, InteractionHandler {
 
     @Override
     public void clicked(@NotNull Component component, @NotNull IFSlotClickContext context) {}
+
+    @Override
+    public Ref<Component> getReference() {
+        return null;
+    }
+
+    @Override
+    public void forceUpdate() {}
 }

--- a/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
+++ b/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/component/FakeComponent.java
@@ -106,4 +106,10 @@ public class FakeComponent implements Component, InteractionHandler {
 
     @Override
     public void forceUpdate() {}
+
+    @Override
+    public void show() {}
+
+    @Override
+    public void hide() {}
 }


### PR DESCRIPTION
Refs API allows user to keep strong references to any element inside a context or even a entire context. Most common usage will be to hold component references like from `slot`, `layoutSlot`, etc.

Closes #473

##### Current API design

Design is purposely similar to State Management API for the user to become familiar with it more easily.
* To create a ref `ref()` - to create a state `state()`
* To assign a ref `.ref()` somewhere - to watch a state `.watch()` somewhere.

Ref must be a top-level (like states) to allow user use it in any handler like global click handler or global update handler, anywhere.

The following code wasn't *really* possible (was possible but hard) to do before.

```java
class MyView extends View {

    private final Ref<Component> sugarRef = ref();

    @Override
    public void onFirstRender(RenderContext context) {
        render.firstSlot(new ItemStack(Material.SUGAR))
            .referencedBy(sugarRef); // <-- Assigns `sugarRef` to SUGAR item
    }

    @Override
    public void onClick(SlotClickContext context) {
        Component sugar = sugarRef.value(context);

        // do something with sugar like hide
        sugar.hide();
    }
}
```

Another possible usage is: hide X item when Y is clicked. Currently is possible to do it with a combo of `displayIf` + `watch` + State Management API

###### Hiding an item with State Management API

```java
class MyView extends View {

    private final MutableState<Boolean> isSugarVisibleState = mutableState(true);

    @Override
    public void onFirstRender(RenderContext context) {
        render.firstSlot(new ItemStack(Material.SUGAR))
            .displayIf(isSugarVisibleState::get)
            .watch(isSugarVisibleState);

        render.lastSlot(new ItemStack(Material.REDSTONE))
            .cancelOnClick()
            .onClick(click -> {
                // Changes `isSugarVisibleState` to hide sugar
                isSugarVisibleState.set(false, click);
            });
    }
}
```

With Refs API this can be done by holding a reference to sugar, not only this, you can: update, remove completely (not only hide/show), move, do anything.

###### Hiding an item with Refs API

```java
class MyView extends View {

    private final Ref<Component> sugarRef = ref();

    @Override
    public void onFirstRender(RenderContext context) {
        render.firstSlot(new ItemStack(Material.SUGAR))
            .referencedBy(sugarRef); // <-- Assigns `sugarRef` to SUGAR item

        render.lastSlot(new ItemStack(Material.REDSTONE))
            .cancelOnClick()
            .onClick(click -> {
                final Component sugar = sugarRef.get(click);

                // You can do anything with sugar here
                sugar.hide(); // Hides SUGAR
                sugar.update(); // Performs a update on SUGAR
            });
    }
}
```

A "multi ref" variant must be created to allow bulk-change on a lot of references at once, i don't know how it will be now.

Possibly a `ComponentRef` interface that is a `Ref<Component>` will be created to avoid excessive `Component` reference in end-user code since, since now any direct reference to non-platform code are purposely hidden so will be not different in that case.
