### PR TITLE
Force inventory of all viewers to be close before first open

### DIFF
--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
@@ -161,6 +161,7 @@ abstract class IFViewFrame<S extends IFViewFrame<S, V>, V extends PlatformView<S
                 .map(player -> view.getElementFactory().createViewer(player, null))
                 .collect(Collectors.toList());
 
+        viewers.forEach(Viewer::close);
         view.open(viewers, initialData);
     }
 


### PR DESCRIPTION
Related to MC 1.8 using F6 keys to bypass inventory handlers, Bukkit do not dispatch InventoryCloseEvent if player uses F6 and then ESC