### PR TITLE
Use regular update mechanism to determine component visibility on change

### DIFF
--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ComponentBuilder.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ComponentBuilder.java
@@ -102,6 +102,7 @@ public interface ComponentBuilder<S extends ComponentBuilder<S, C>, C extends IF
      * @param states The state to listen changes to.
      * @return This component builder.
      */
+	// TODO Add first parameter to this overload to not allow updateOnStateChange() (no parameters)
     S updateOnStateChange(State<?>... states);
 
     /**

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ComponentBuilder.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ComponentBuilder.java
@@ -102,7 +102,7 @@ public interface ComponentBuilder<S extends ComponentBuilder<S, C>, C extends IF
      * @param states The state to listen changes to.
      * @return This component builder.
      */
-	// TODO Add first parameter to this overload to not allow updateOnStateChange() (no parameters)
+    // TODO Add first parameter to this overload to not allow updateOnStateChange() (no parameters)
     S updateOnStateChange(State<?>... states);
 
     /**

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
@@ -243,15 +243,13 @@ public class ItemComponent implements Component, InteractionHandler {
     @Override
     public void hide() {
         setVisible(false);
-
-        // TODO Change update mechanism to allow in-ComponentComposition child to be hidden
-        clear((IFContext) getRoot());
+		update();
     }
 
     @Override
     public void show() {
         setVisible(true);
-        forceUpdate();
+        update();
     }
 
     @Override

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/component/ItemComponent.java
@@ -243,7 +243,7 @@ public class ItemComponent implements Component, InteractionHandler {
     @Override
     public void hide() {
         setVisible(false);
-		update();
+        update();
     }
 
     @Override


### PR DESCRIPTION
Ensures that component use unified update & re-render mechanism to determine it's own visibility instead of removing it manually from current container (which is wrong).

Currently `hide()` calls `setVisible(false)` then `clear()` that removes physical component from the container.

Now `hide()` calls `setVisible(false)` then `update()` that relies on unified context-hold update & re-render mechanism to determine if that component must be visible or not also, this mechanism determines if other components like overlapping ones should be shown when this component gets shown/hidden.

The major problem here is that `clear() removes physical component from the container, virtual component stills so any interaction on the empty slot will call that (currently hidden) component, interactions handlers, anything will work even if the physical item cannot be seen by the player. Also, this behavior in child components (e.g. components inside a ComponentComposition) is unknown.

This affects any visibility-related things like `displayIf`, `hideIf`, `hide()`, `show()` etc.