### PR TITLE
Initial data transitivity option

### DIFF
--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/ViewConfig.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/ViewConfig.java
@@ -29,6 +29,7 @@ public class ViewConfig {
     private final String[] layout;
     private final Set<Modifier> modifiers;
     private final long updateIntervalInTicks, interactionDelayInMillis;
+    private final boolean transitiveInitialData;
 
     public ViewConfig(
             Object title,
@@ -38,7 +39,8 @@ public class ViewConfig {
             String[] layout,
             Set<Modifier> modifiers,
             long updateIntervalInTicks,
-            long interactionDelayInMillis) {
+            long interactionDelayInMillis,
+            boolean transitiveInitialData) {
         this.title = title;
         this.size = size;
         this.type = type;
@@ -47,6 +49,7 @@ public class ViewConfig {
         this.modifiers = modifiers;
         this.updateIntervalInTicks = updateIntervalInTicks;
         this.interactionDelayInMillis = interactionDelayInMillis;
+        this.transitiveInitialData = transitiveInitialData;
     }
 
     public Object getTitle() {
@@ -79,6 +82,10 @@ public class ViewConfig {
 
     public long getInteractionDelayInMillis() {
         return interactionDelayInMillis;
+    }
+
+    public boolean isTransitiveInitialData() {
+        return transitiveInitialData;
     }
 
     @VisibleForTesting
@@ -138,7 +145,8 @@ public class ViewConfig {
                 merge(other, ViewConfig::getLayout),
                 merge(other, ViewConfig::getModifiers, value -> value != null && !value.isEmpty()),
                 merge(other, ViewConfig::getUpdateIntervalInTicks, value -> value != 0),
-                merge(other, ViewConfig::getInteractionDelayInMillis, value -> value != 0));
+                merge(other, ViewConfig::getInteractionDelayInMillis, value -> value != 0),
+                merge(other, ViewConfig::isTransitiveInitialData));
     }
 
     private <T> T merge(ViewConfig other, Function<ViewConfig, T> retriever) {
@@ -228,7 +236,8 @@ public class ViewConfig {
                 && Objects.equals(getType(), that.getType())
                 && Objects.equals(getOptions(), that.getOptions())
                 && Arrays.equals(getLayout(), that.getLayout())
-                && Objects.equals(getModifiers(), that.getModifiers());
+                && Objects.equals(getModifiers(), that.getModifiers())
+                && isTransitiveInitialData() == that.isTransitiveInitialData();
     }
 
     @Override
@@ -240,7 +249,8 @@ public class ViewConfig {
                 getOptions(),
                 getModifiers(),
                 getUpdateIntervalInTicks(),
-                getInteractionDelayInMillis());
+                getInteractionDelayInMillis(),
+                isTransitiveInitialData());
         result = 31 * result + Arrays.hashCode(getLayout());
         return result;
     }
@@ -255,6 +265,7 @@ public class ViewConfig {
                 + Arrays.toString(layout) + ", modifiers="
                 + modifiers + ", updateIntervalInTicks="
                 + updateIntervalInTicks + ", interactionDelayInMillis="
-                + interactionDelayInMillis + '}';
+                + interactionDelayInMillis + ", transitiveInitialData="
+                + transitiveInitialData + "}";
     }
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/ViewConfigBuilder.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/ViewConfigBuilder.java
@@ -227,7 +227,7 @@ public final class ViewConfigBuilder {
                 getModifiers(),
                 getUpdateIntervalInTicks(),
                 getInteractionDelayInMillis(),
-			transitiveInitialData);
+                transitiveInitialData);
     }
 
     public static boolean isTitleAsComponentSupported() {
@@ -266,7 +266,7 @@ public final class ViewConfigBuilder {
         return interactionDelayInMillis;
     }
 
-	public boolean isTransitiveInitialData() {
-		return transitiveInitialData;
-	}
+    public boolean isTransitiveInitialData() {
+        return transitiveInitialData;
+    }
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/ViewConfigBuilder.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/ViewConfigBuilder.java
@@ -31,6 +31,7 @@ public final class ViewConfigBuilder {
     private String[] layout = null;
     private final Set<ViewConfig.Modifier> modifiers = new HashSet<>();
     private long updateIntervalInTicks, interactionDelayInMillis;
+    private boolean transitiveData;
 
     /**
      * Inherits all configuration from another {@link ViewConfigBuilder} value.
@@ -193,6 +194,21 @@ public final class ViewConfigBuilder {
     @ApiStatus.Experimental
     public ViewConfigBuilder interactionDelay(Duration interactionDelay) {
         this.interactionDelayInMillis = interactionDelay == null ? 0 : interactionDelay.toMillis();
+        return this;
+    }
+
+    /**
+     * When navigating between views data from "A" to "B" is not carried so trying to access
+     * some data from "A" in "B" will throw a {@link NullPointerException}.
+     * <p>
+     * This behavior can be changed by enabling this option, once enabled, on every navigation
+     * between views data will be carried from the view where came from to the view where are going.
+     *
+     * @return This configuration builder.
+     * @see <a href="https://github.com/DevNatan/inventory-framework/wiki/navigating-between-views">Navigating Between Views on Wiki</a>
+     */
+    public ViewConfigBuilder transitiveInitialData(boolean transitiveInitialData) {
+        this.transitiveData = transitiveInitialData;
         return this;
     }
 

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/ViewConfigBuilder.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/ViewConfigBuilder.java
@@ -31,7 +31,7 @@ public final class ViewConfigBuilder {
     private String[] layout = null;
     private final Set<ViewConfig.Modifier> modifiers = new HashSet<>();
     private long updateIntervalInTicks, interactionDelayInMillis;
-    private boolean transitiveData;
+    private boolean transitiveInitialData;
 
     /**
      * Inherits all configuration from another {@link ViewConfigBuilder} value.
@@ -208,7 +208,7 @@ public final class ViewConfigBuilder {
      * @see <a href="https://github.com/DevNatan/inventory-framework/wiki/navigating-between-views">Navigating Between Views on Wiki</a>
      */
     public ViewConfigBuilder transitiveInitialData(boolean transitiveInitialData) {
-        this.transitiveData = transitiveInitialData;
+        this.transitiveInitialData = transitiveInitialData;
         return this;
     }
 
@@ -226,7 +226,8 @@ public final class ViewConfigBuilder {
                 getLayout(),
                 getModifiers(),
                 getUpdateIntervalInTicks(),
-                getInteractionDelayInMillis());
+                getInteractionDelayInMillis(),
+			transitiveInitialData);
     }
 
     public static boolean isTitleAsComponentSupported() {
@@ -264,4 +265,8 @@ public final class ViewConfigBuilder {
     long getInteractionDelayInMillis() {
         return interactionDelayInMillis;
     }
+
+	public boolean isTransitiveInitialData() {
+		return transitiveInitialData;
+	}
 }

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformConfinedContext.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformConfinedContext.java
@@ -21,18 +21,19 @@ abstract class PlatformConfinedContext extends PlatformContext implements IFConf
 
     @Override
     public void openForPlayer(@NotNull Class<? extends RootView> other) {
-        openForPlayer(other, getConfig().isTransitiveInitialData() ? getInitialData() : null);
+        openForPlayer(other, getConfig().isTransitiveInitialData() ? getInitialData() : null, false);
+    }
+
+    @Override
+    public void openForPlayer(@NotNull Class<? extends RootView> other, Object initialData) {
+        openForPlayer(other, initialData, true);
     }
 
     @SuppressWarnings("unchecked")
-    @Override
-    public void openForPlayer(@NotNull Class<? extends RootView> other, Object initialData) {
-        getRoot()
-                .navigateTo(
-                        other,
-                        (IFRenderContext) this,
-                        getViewer(),
-                        getConfig().isTransitiveInitialData() ? mergeInitialData(initialData) : initialData);
+    private void openForPlayer(@NotNull Class<? extends RootView> other, Object initialData, boolean mergeInitialData) {
+        final Object data =
+                getConfig().isTransitiveInitialData() && mergeInitialData ? mergeInitialData(initialData) : initialData;
+        getRoot().navigateTo(other, (IFRenderContext) this, getViewer(), data);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})


### PR DESCRIPTION
Creates an option to always carry initial data from "A" to "B" on navigate. This is a bug because this was supposed to be the default behavior. An option was created to preserve the behavior of previously created views.

#### This option determines if **A** should carry its initial data to **B**.

Can be enabled for a specific view using `transitiveInitialData(Boolean)`

```java
@Override
public void onInit(ViewConfigBuilder config) {
    config.transitiveInitialData(true);
}
```

Enabled for all views on ViewFrame default config

```java
viewFrame.defaultConfig(config -> config.transitiveInitialData(true));
```

And be disabled for a specific view after enabling globally

```java
@Override
public void onInit(ViewConfigBuilder config) {
    config.transitiveInitialData(false);
}
```

This options changes the behavior of `openToPlayer(Class)`.
Data provided in `openToPlayer(Class, Object)` will be merged with the transitive one.

Closes #441