### PR TITLE
createEndlessContext

### DIFF
--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/RootView.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/RootView.java
@@ -1,6 +1,5 @@
 package me.devnatan.inventoryframework;
 
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import me.devnatan.inventoryframework.context.IFContext;
@@ -9,7 +8,6 @@ import me.devnatan.inventoryframework.internal.Job;
 import me.devnatan.inventoryframework.pipeline.Pipeline;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.UnmodifiableView;
 
 public interface RootView extends VirtualView {
 
@@ -27,10 +25,9 @@ public interface RootView extends VirtualView {
      * <b><i> This is an internal inventory-framework API that should not be used from outside of
      * this library. No compatibility guarantees are provided. </i></b>
      *
-     * @return An unmodifiable set of all currently active contexts in this view.
+     * @return An set of all currently active contexts in this view.
      */
     @ApiStatus.Internal
-    @UnmodifiableView
     Set<IFContext> getInternalContexts();
 
     /**
@@ -95,6 +92,10 @@ public interface RootView extends VirtualView {
     @ApiStatus.Internal
     void setScheduledUpdateJob(@NotNull Job job);
 
-    @NotNull
-    Map<String, Object> getMetadata();
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    void invalidateContext(String contextId);
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/RootView.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/RootView.java
@@ -25,7 +25,7 @@ public interface RootView extends VirtualView {
      * <b><i> This is an internal inventory-framework API that should not be used from outside of
      * this library. No compatibility guarantees are provided. </i></b>
      *
-     * @return An set of all currently active contexts in this view.
+     * @return A set of all currently active contexts in this view.
      */
     @ApiStatus.Internal
     Set<IFContext> getInternalContexts();
@@ -97,5 +97,5 @@ public interface RootView extends VirtualView {
      * this library. No compatibility guarantees are provided. </i></b>
      */
     @ApiStatus.Internal
-    void invalidateContext(String contextId);
+    void invalidateEndlessContext(String contextId);
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/EndlessContextData.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/EndlessContextData.java
@@ -1,0 +1,45 @@
+package me.devnatan.inventoryframework.context;
+
+import java.util.Objects;
+import me.devnatan.inventoryframework.RootView;
+
+public final class EndlessContextData {
+
+    private final String contextId;
+    private final RootView view;
+
+    public EndlessContextData(String contextId, RootView view) {
+        this.contextId = contextId;
+        this.view = view;
+    }
+
+    public String getContextId() {
+        return contextId;
+    }
+
+    public RootView getView() {
+        return view;
+    }
+
+    public void invalidate() {
+        getView().invalidateContext(contextId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EndlessContextData that = (EndlessContextData) o;
+        return Objects.equals(contextId, that.contextId) && Objects.equals(view, that.view);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(contextId, view);
+    }
+
+    @Override
+    public String toString() {
+        return "EndlessContextData{" + "contextId='" + contextId + '\'' + ", view=" + view + '}';
+    }
+}

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/EndlessContextData.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/EndlessContextData.java
@@ -7,6 +7,7 @@ public final class EndlessContextData {
 
     private final String contextId;
     private final RootView view;
+    private boolean invalidated;
 
     public EndlessContextData(String contextId, RootView view) {
         this.contextId = contextId;
@@ -22,7 +23,12 @@ public final class EndlessContextData {
     }
 
     public void invalidate() {
-        getView().invalidateContext(contextId);
+        getView().invalidateEndlessContext(contextId);
+        invalidated = true;
+    }
+
+    public boolean wasInvalidated() {
+        return invalidated;
     }
 
     @Override

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/EndlessContextInfo.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/EndlessContextInfo.java
@@ -3,13 +3,13 @@ package me.devnatan.inventoryframework.context;
 import java.util.Objects;
 import me.devnatan.inventoryframework.RootView;
 
-public final class EndlessContextData {
+public final class EndlessContextInfo {
 
     private final String contextId;
     private final RootView view;
     private boolean invalidated;
 
-    public EndlessContextData(String contextId, RootView view) {
+    public EndlessContextInfo(String contextId, RootView view) {
         this.contextId = contextId;
         this.view = view;
     }
@@ -35,7 +35,7 @@ public final class EndlessContextData {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        EndlessContextData that = (EndlessContextData) o;
+        EndlessContextInfo that = (EndlessContextInfo) o;
         return Objects.equals(contextId, that.contextId) && Objects.equals(view, that.view);
     }
 

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFContext.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFContext.java
@@ -239,4 +239,18 @@ public interface IFContext extends VirtualView, StateValueHost, ComponentContain
      */
     @ApiStatus.Internal
     void setActive(boolean active);
+
+	/**
+	 * <b><i> This is an internal inventory-framework API that should not be used from outside of
+	 * this library. No compatibility guarantees are provided. </i></b>
+	 */
+	@ApiStatus.Internal
+	boolean isEndless();
+
+	/**
+	 * <b><i> This is an internal inventory-framework API that should not be used from outside of
+	 * this library. No compatibility guarantees are provided. </i></b>
+	 */
+	@ApiStatus.Internal
+	void setEndless(boolean endless);
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFContext.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFContext.java
@@ -240,17 +240,17 @@ public interface IFContext extends VirtualView, StateValueHost, ComponentContain
     @ApiStatus.Internal
     void setActive(boolean active);
 
-	/**
-	 * <b><i> This is an internal inventory-framework API that should not be used from outside of
-	 * this library. No compatibility guarantees are provided. </i></b>
-	 */
-	@ApiStatus.Internal
-	boolean isEndless();
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    boolean isEndless();
 
-	/**
-	 * <b><i> This is an internal inventory-framework API that should not be used from outside of
-	 * this library. No compatibility guarantees are provided. </i></b>
-	 */
-	@ApiStatus.Internal
-	void setEndless(boolean endless);
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    void setEndless(boolean endless);
 }

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/DefaultRootView.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/DefaultRootView.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 @ApiStatus.NonExtendable
-public class DefaultRootView implements RootView {
+public abstract class DefaultRootView implements RootView {
 
     private final UUID id = UUID.randomUUID();
     private ViewConfig config;
@@ -30,7 +30,6 @@ public class DefaultRootView implements RootView {
     private final Set<IFContext> contexts = newSetFromMap(synchronizedMap(new HashMap<>()));
     final StateRegistry stateRegistry = new StateRegistry();
     private Job scheduledUpdateJob;
-    private final Map<String, Object> metadata = new HashMap<>();
 
     @Override
     public final @NotNull UUID getUniqueId() {
@@ -81,11 +80,5 @@ public class DefaultRootView implements RootView {
     @Override
     public final void setScheduledUpdateJob(@NotNull Job job) {
         this.scheduledUpdateJob = job;
-    }
-
-    @NotNull
-    @Override
-    public final Map<String, Object> getMetadata() {
-        return metadata;
     }
 }

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/context/AbstractIFContext.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/context/AbstractIFContext.java
@@ -8,6 +8,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import me.devnatan.inventoryframework.IFDebug;
 import me.devnatan.inventoryframework.InventoryFrameworkException;
 import me.devnatan.inventoryframework.UnsupportedOperationInSharedContextException;
 import me.devnatan.inventoryframework.ViewConfig;
@@ -42,6 +43,9 @@ abstract class AbstractIFContext extends DefaultStateValueHost implements IFCont
         synchronized (getIndexedViewers()) {
             getIndexedViewers().put(viewer.getId(), viewer);
         }
+
+        IFDebug.debug(
+                "Viewer %s added to %s", viewer.getId(), getRoot().getClass().getName());
     }
 
     @Override
@@ -49,6 +53,9 @@ abstract class AbstractIFContext extends DefaultStateValueHost implements IFCont
         synchronized (getIndexedViewers()) {
             getIndexedViewers().remove(viewer.getId());
         }
+        IFDebug.debug(
+                "Viewer %s removed from %s",
+                viewer.getId(), getRoot().getClass().getName());
     }
 
     @Override

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/ViewFrame.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/ViewFrame.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.UnaryOperator;
+import me.devnatan.inventoryframework.context.EndlessContextInfo;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.feature.DefaultFeatureInstaller;
 import me.devnatan.inventoryframework.feature.Feature;
@@ -121,9 +122,62 @@ public class ViewFrame extends IFViewFrame<ViewFrame, View> {
     @ApiStatus.Experimental
     public final void openActive(
             @NotNull Class<? extends View> viewClass, @NotNull String contextId, @NotNull Player player) {
-        internalOpenActiveContext(viewClass, contextId, player, null);
+        openActive(viewClass, contextId, player, null);
     }
 
+    /**
+     * Opens an already active context to a player.
+     * <p>
+     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param contextId The id of the context.
+     * @param player Who the context will be open to.
+     * @param initialData Initial data to pass to {@link PlatformView#onViewerAdded(IFContext, Object, Object)}.
+     */
+    @ApiStatus.Experimental
+    public final void openActive(
+            @NotNull Class<? extends View> viewClass,
+            @NotNull String contextId,
+            @NotNull Player player,
+            Object initialData) {
+        internalOpenActiveContext(viewClass, contextId, player, initialData);
+    }
+
+    /**
+     * Opens an already active context to a player.
+     * <p>
+     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param endlessContextInfo The id of the context.
+     * @param player Who the context will be open to.
+     */
+    @ApiStatus.Experimental
+    public final void openEndless(@NotNull EndlessContextInfo endlessContextInfo, @NotNull Player player) {
+        openEndless(endlessContextInfo, player, null);
+    }
+
+    /**
+     * Opens an already active context to a player.
+     * <p>
+     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param endlessContextInfo The id of the context.
+     * @param player Who the context will be open to.
+     * @param initialData Initial data to pass to {@link PlatformView#onViewerAdded(IFContext, Object, Object)}.
+     */
+    @SuppressWarnings("unchecked")
+    @ApiStatus.Experimental
+    public final void openEndless(
+            @NotNull EndlessContextInfo endlessContextInfo, @NotNull Player player, Object initialData) {
+        openActive(
+                (Class<? extends View>) endlessContextInfo.getView().getClass(),
+                endlessContextInfo.getContextId(),
+                player,
+                initialData);
+    }
     // endregion
 
     @Override

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/SlotContext.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/SlotContext.java
@@ -181,7 +181,17 @@ public abstract class SlotContext extends PlatformContext implements IFSlotConte
         getParent().setActive(active);
     }
 
-    @Override
+	@Override
+	public final boolean isEndless() {
+		return getParent().isEndless();
+	}
+
+	@Override
+	public final void setEndless(boolean endless) {
+		getParent().setEndless(endless);
+	}
+
+	@Override
     public void back() {
         getParent().back();
     }

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/SlotContext.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/SlotContext.java
@@ -181,17 +181,17 @@ public abstract class SlotContext extends PlatformContext implements IFSlotConte
         getParent().setActive(active);
     }
 
-	@Override
-	public final boolean isEndless() {
-		return getParent().isEndless();
-	}
+    @Override
+    public final boolean isEndless() {
+        return getParent().isEndless();
+    }
 
-	@Override
-	public final void setEndless(boolean endless) {
-		getParent().setEndless(endless);
-	}
+    @Override
+    public final void setEndless(boolean endless) {
+        getParent().setEndless(endless);
+    }
 
-	@Override
+    @Override
     public void back() {
         getParent().back();
     }

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
@@ -178,6 +178,20 @@ abstract class IFViewFrame<S extends IFViewFrame<S, V>, V extends PlatformView<S
         view.open(contextId, convertedViewer, initialData);
     }
 
+    /**
+     * Creates a context that is never invalidated.
+     * <p>
+     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param viewClass The view of the context to be later opened.
+     * @return The id of the context.
+     */
+    @ApiStatus.Experimental
+    public final String createIndefiniteContext(@NotNull Class<? extends RootView> viewClass) {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
     void addViewer(@NotNull Viewer viewer) {
         synchronized (viewerById) {
             viewerById.put(viewer.getId(), viewer);

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
@@ -192,6 +192,22 @@ abstract class IFViewFrame<S extends IFViewFrame<S, V>, V extends PlatformView<S
 		throw new UnsupportedOperationException("Not implemented.");
 	}
 
+	/**
+	 * Invalidates a context created by {@link #createIndefiniteContext(Class)}.
+	 * <p>
+	 * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+	 * such API may be changed or may be removed completely in any further release. </i></b>
+	 *
+	 * @param viewClass The view of the context to be later opened.
+	 */
+	@ApiStatus.Experimental
+	public final void invalidateIndefiniteContext(
+		@NotNull Class<? extends RootView> viewClass,
+		@NotNull String contextId
+	) {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
     void addViewer(@NotNull Viewer viewer) {
         synchronized (viewerById) {
             viewerById.put(viewer.getId(), viewer);

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import me.devnatan.inventoryframework.context.EndlessContextData;
+import me.devnatan.inventoryframework.context.EndlessContextInfo;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.pipeline.Pipeline;
 import me.devnatan.inventoryframework.pipeline.PipelinePhase;
@@ -189,7 +189,7 @@ abstract class IFViewFrame<S extends IFViewFrame<S, V>, V extends PlatformView<S
      * @return The id of the context.
      */
     @ApiStatus.Experimental
-    public final EndlessContextData createEndlessContext(@NotNull Class<? extends RootView> viewClass) {
+    public final EndlessContextInfo createEndlessContext(@NotNull Class<? extends RootView> viewClass) {
         return createEndlessContext(viewClass, null);
     }
 
@@ -204,11 +204,11 @@ abstract class IFViewFrame<S extends IFViewFrame<S, V>, V extends PlatformView<S
      * @return The id of the context.
      */
     @ApiStatus.Experimental
-    public final EndlessContextData createEndlessContext(
+    public final EndlessContextInfo createEndlessContext(
             @NotNull Class<? extends RootView> viewClass, Object initialData) {
         final V view = getRegisteredViewByType(viewClass);
         final String context = view.createEndless(initialData);
-        return new EndlessContextData(context, view);
+        return new EndlessContextInfo(context, view);
     }
 
     void addViewer(@NotNull Viewer viewer) {

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import me.devnatan.inventoryframework.context.EndlessContextData;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.pipeline.Pipeline;
 import me.devnatan.inventoryframework.pipeline.PipelinePhase;
@@ -188,36 +189,40 @@ abstract class IFViewFrame<S extends IFViewFrame<S, V>, V extends PlatformView<S
      * @return The id of the context.
      */
     @ApiStatus.Experimental
-    public final String createIndefiniteContext(@NotNull Class<? extends RootView> viewClass) {
-		throw new UnsupportedOperationException("Not implemented.");
-	}
+    public final EndlessContextData createEndlessContext(@NotNull Class<? extends RootView> viewClass) {
+        return createEndlessContext(viewClass, null);
+    }
 
-	/**
-	 * Invalidates a context created by {@link #createIndefiniteContext(Class)}.
-	 * <p>
-	 * <b><i> This API is experimental and is not subject to the general compatibility guarantees
-	 * such API may be changed or may be removed completely in any further release. </i></b>
-	 *
-	 * @param viewClass The view of the context to be later opened.
-	 */
-	@ApiStatus.Experimental
-	public final void invalidateIndefiniteContext(
-		@NotNull Class<? extends RootView> viewClass,
-		@NotNull String contextId
-	) {
-		throw new UnsupportedOperationException("Not implemented.");
-	}
+    /**
+     * Creates a context that is never invalidated.
+     * <p>
+     * <b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param viewClass The view of the context to be later opened.
+     * @param initialData Initial setup data to pass to opening handler.
+     * @return The id of the context.
+     */
+    @ApiStatus.Experimental
+    public final EndlessContextData createEndlessContext(
+            @NotNull Class<? extends RootView> viewClass, Object initialData) {
+        final V view = getRegisteredViewByType(viewClass);
+        final String context = view.createEndless(initialData);
+        return new EndlessContextData(context, view);
+    }
 
     void addViewer(@NotNull Viewer viewer) {
         synchronized (viewerById) {
             viewerById.put(viewer.getId(), viewer);
         }
+        IFDebug.debug("Viewer added globally %s", viewer.getId());
     }
 
     void removeViewer(@NotNull Viewer viewer) {
         synchronized (viewerById) {
             viewerById.remove(viewer.getId());
         }
+        IFDebug.debug("Viewer removed globally %s", viewer.getId());
     }
 
     /**

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -2,6 +2,7 @@ package me.devnatan.inventoryframework;
 
 import static java.lang.String.format;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -72,10 +73,25 @@ public abstract class PlatformView<
     }
 
     /**
+     * Setups a endless context.
+     *
+     * @param initialData Initial data to pass through opening handler.
+     * @return The id of the generated context.
+     */
+    final String createEndless(Object initialData) {
+        final IFOpenContext context = getElementFactory().createOpenContext(this, null, new ArrayList<>(), initialData);
+
+        context.setEndless(true);
+        getPipeline().execute(StandardPipelinePhases.OPEN, context);
+        return context.getId().toString();
+    }
+
+    /**
      * Opens this view to one or more viewers.
      *
      * @param viewers     The viewers that'll see this view.
      * @param initialData The initial data.
+     * @return The id of the generated context.
      */
     final String open(List<Viewer> viewers, Object initialData) {
         if (!isInitialized()) throw new IllegalStateException("Cannot open a uninitialized view");
@@ -260,6 +276,7 @@ public abstract class PlatformView<
         synchronized (getInternalContexts()) {
             getInternalContexts().add(context);
         }
+        IFDebug.debug("Context %s added to %s", context.getId(), getClass().getName());
     }
 
     /**
@@ -275,6 +292,7 @@ public abstract class PlatformView<
         synchronized (getInternalContexts()) {
             getInternalContexts().removeIf(other -> other.getId() == context.getId());
         }
+        IFDebug.debug("Context %s removed from %s", context.getId(), getClass().getName());
     }
 
     /**
@@ -310,6 +328,7 @@ public abstract class PlatformView<
             if (!context.getContainer().isProxied()) context.getContainer().open(viewer);
             viewer.setTransitioning(false);
         });
+        IFDebug.debug("Rendering context %s", context.getId());
     }
 
     @SuppressWarnings("rawtypes")
@@ -323,12 +342,24 @@ public abstract class PlatformView<
         final IFRenderContext target =
                 viewer.isTransitioning() ? viewer.getPreviousContext() : viewer.getActiveContext();
 
-        if (target == null) return;
-
+        if (target == null || target.isEndless()) return;
         if (target.getViewers().isEmpty()) {
             target.setActive(false);
             removeContext(target);
         }
+    }
+
+    @Override
+    public void invalidateContext(String contextId) {
+        IFDebug.debug("Invalidating context %s...", contextId);
+        final IFContext context = getInternalContexts().stream()
+                .filter(value -> value.getId().toString().equals(contextId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Context not found: " + contextId));
+
+        if (!context.isActive() || context.isEndless()) return;
+
+        context.closeForEveryone();
     }
     // endregion
 

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformContext.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformContext.java
@@ -6,9 +6,11 @@ import org.jetbrains.annotations.Nullable;
 
 public abstract class PlatformContext extends AbstractIFContext {
 
+	private boolean endless;
     private boolean active = true;
 
-    PlatformContext() {}
+    PlatformContext() {
+	}
 
     @SuppressWarnings("rawtypes")
     @Override
@@ -88,4 +90,14 @@ public abstract class PlatformContext extends AbstractIFContext {
     public void setActive(boolean active) {
         this.active = active;
     }
+
+	@Override
+	public boolean isEndless() {
+		return endless;
+	}
+
+	@Override
+	public void setEndless(boolean endless) {
+		this.endless = endless;
+	}
 }

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformContext.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformContext.java
@@ -6,11 +6,10 @@ import org.jetbrains.annotations.Nullable;
 
 public abstract class PlatformContext extends AbstractIFContext {
 
-	private boolean endless;
+    private boolean endless;
     private boolean active = true;
 
-    PlatformContext() {
-	}
+    PlatformContext() {}
 
     @SuppressWarnings("rawtypes")
     @Override
@@ -91,13 +90,13 @@ public abstract class PlatformContext extends AbstractIFContext {
         this.active = active;
     }
 
-	@Override
-	public boolean isEndless() {
-		return endless;
-	}
+    @Override
+    public boolean isEndless() {
+        return endless;
+    }
 
-	@Override
-	public void setEndless(boolean endless) {
-		this.endless = endless;
-	}
+    @Override
+    public void setEndless(boolean endless) {
+        this.endless = endless;
+    }
 }

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/pipeline/PlatformOpenInterceptor.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/pipeline/PlatformOpenInterceptor.java
@@ -83,6 +83,7 @@ public final class PlatformOpenInterceptor implements PipelineInterceptor<Virtua
                 openContext.getViewer(),
                 openContext.getInitialData());
 
+        context.setEndless(openContext.isEndless());
         openContext.getStateValues().forEach(context::initializeState);
 
         for (final Viewer viewer : openContext.getIndexedViewers().values()) {


### PR DESCRIPTION
`createEndlessContext` creates a context that is not invalidated when all viewers are released from it.

Create a endless context using *createEndlessContext*
```java
EndlessContextInfo endlessContextInfo = vf.createEndlessContext(SomeView.class);
```

Open it using *openEndless*
```java
vf.openEndless(endlessContextInfo, player)
```

Initial data can be passed to be later accessed in onViewerAdded
```java
vf.openEndless(endlessContextInfo, player, something)
```

Invalidate when its no more needed
```java
endlessContextInfo.invalidate();
```