### PR TITLE
Remove reserved layout character restriction

### DIFF
--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/internal/LayoutSlot.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/internal/LayoutSlot.java
@@ -8,8 +8,7 @@ import org.jetbrains.annotations.Nullable;
 
 public final class LayoutSlot {
 
-    // Retro compatibility
-    public static final char FILLED_RESERVED_CHAR = 'O';
+    public static final char DEFAULT_SLOT_FILL_CHAR = 'O';
 
     private final char character;
     private final IntFunction<ComponentFactory> factory;

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/AvailableSlotInterceptor.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/AvailableSlotInterceptor.java
@@ -65,7 +65,7 @@ public final class AvailableSlotInterceptor implements PipelineInterceptor<Virtu
     @VisibleForTesting
     List<ComponentBuilder> resolveFromLayoutSlot(IFRenderContext context) {
         final Optional<LayoutSlot> layoutSlotOption = context.getLayoutSlots().stream()
-                .filter(layoutSlot -> layoutSlot.getCharacter() == LayoutSlot.FILLED_RESERVED_CHAR)
+                .filter(layoutSlot -> layoutSlot.getCharacter() == LayoutSlot.DEFAULT_SLOT_FILL_CHAR)
                 .findFirst();
 
         if (!layoutSlotOption.isPresent()) return Collections.emptyList();

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/component/PaginationBuilder.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/component/PaginationBuilder.java
@@ -13,7 +13,7 @@ public final class PaginationBuilder<CONTEXT, BUILDER, V>
 
     private final ElementFactory internalElementFactory;
     private final Object sourceProvider;
-    private char layoutTarget = LayoutSlot.FILLED_RESERVED_CHAR;
+    private char layoutTarget = LayoutSlot.DEFAULT_SLOT_FILL_CHAR;
     private PaginationElementFactory<V> paginationElementFactory;
     private BiConsumer<CONTEXT, Pagination> pageSwitchHandler;
     private final boolean async, computed;
@@ -79,7 +79,7 @@ public final class PaginationBuilder<CONTEXT, BUILDER, V>
      * <p>
      * By default, if there is a layout available and a target character has not
      * been explicitly  defined in the layout, the layout's rendering target
-     * character will be the {@link LayoutSlot#FILLED_RESERVED_CHAR reserved layout character}.
+     * character will be the {@link LayoutSlot#DEFAULT_SLOT_FILL_CHAR default layout character}.
      * <p>
      * If there is no layout configured, pagination will be rendered throughout the view container.
      *

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformRenderContext.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformRenderContext.java
@@ -1,6 +1,5 @@
 package me.devnatan.inventoryframework.context;
 
-import static java.lang.String.format;
 import static me.devnatan.inventoryframework.utils.SlotConverter.convertSlot;
 
 import java.util.ArrayList;
@@ -186,8 +185,6 @@ public abstract class PlatformRenderContext<ITEM_BUILDER extends ItemComponentBu
      * @return An item builder to configure the item.
      */
     public final @NotNull ITEM_BUILDER layoutSlot(char character) {
-        requireNonReservedLayoutCharacter(character);
-
         // TODO More detailed exception message
         final LayoutSlot layoutSlot = getLayoutSlots().stream()
                 .filter(value -> value.getCharacter() == character)
@@ -209,8 +206,6 @@ public abstract class PlatformRenderContext<ITEM_BUILDER extends ItemComponentBu
      * @param character The layout character target.
      */
     public final void layoutSlot(char character, @NotNull BiConsumer<Integer, ITEM_BUILDER> factory) {
-        requireNonReservedLayoutCharacter(character);
-
         // TODO More detailed exception message
         final LayoutSlot layoutSlot = getLayoutSlots().stream()
                 .filter(value -> value.getCharacter() == character)
@@ -232,7 +227,6 @@ public abstract class PlatformRenderContext<ITEM_BUILDER extends ItemComponentBu
      */
     public @NotNull <BUILDER extends ComponentBuilder, COMPONENT extends PlatformComponent<CONTEXT, BUILDER>>
             BUILDER layoutComponent(char character, COMPONENT component) {
-        requireNonReservedLayoutCharacter(character);
 
         // TODO More detailed exception message
         final LayoutSlot layoutSlot = getLayoutSlots().stream()
@@ -466,19 +460,6 @@ public abstract class PlatformRenderContext<ITEM_BUILDER extends ItemComponentBu
             throw new IllegalStateException(String.format(
                     "Non-aligned container type %s cannot use row-column slots, use absolute %s instead",
                     getContainer().getType().getIdentifier(), "#slot(n)"));
-    }
-
-    /**
-     * Checks if the character is a reserved layout character.
-     *
-     * @param character The character to be checked.
-     * @throws IllegalArgumentException If the given character is a reserved layout character.
-     */
-    private void requireNonReservedLayoutCharacter(char character) {
-        if (character == LayoutSlot.FILLED_RESERVED_CHAR)
-            throw new IllegalArgumentException(format(
-                    "The '%c' character cannot be used because it is only available for backwards compatibility. Please use another character.",
-                    character));
     }
     // endregion
 }


### PR DESCRIPTION
Now is possible to use `render.layoutSlot('O')` as well. This restriction is not needed anymore.