### PR TITLE
Fix context switch workflow and pipeline calls order

### DIFF
--- a/build-logic/conventions/src/main/kotlin/LibraryConventionPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/LibraryConventionPlugin.kt
@@ -14,6 +14,9 @@ import org.gradle.kotlin.dsl.withType
 class LibraryConventionPlugin : Plugin<Project> {
 
     override fun apply(target: Project) = with(target) {
+        group = rootProject.group
+        version = rootProject.version
+
         configureJava()
         configureLint()
         setupDefaultDependencies()

--- a/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/ExampleUtil.kt
+++ b/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/ExampleUtil.kt
@@ -24,7 +24,5 @@ object ExampleUtil {
     fun displayItem(
         material: Material,
         displayName: String,
-    ): ItemStack {
-        return ItemStack.of(material).withCustomName(Component.text(displayName))
-    }
+    ): ItemStack = ItemStack.of(material).withCustomName(Component.text(displayName))
 }

--- a/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/SampleServer.kt
+++ b/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/SampleServer.kt
@@ -45,13 +45,13 @@ class SampleServer {
         }
 
         val viewFrame =
-            ViewFrame.create(handler)
+            ViewFrame
+                .create(handler)
                 .with(
                     Failing(),
                     SimplePagination(),
                     ScheduledView(),
-                )
-                .register()
+                ).register()
 
         MinecraftServer.getCommandManager().register(
             IFExampleCommand(viewFrame),

--- a/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/command/GamemodeCommand.kt
+++ b/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/command/GamemodeCommand.kt
@@ -10,9 +10,12 @@ import net.minestom.server.command.builder.suggestion.SuggestionEntry
 import net.minestom.server.entity.GameMode
 import net.minestom.server.entity.Player
 
-class GamemodeCommand(private val viewFrame: ViewFrame) : Command("gamemode") {
+class GamemodeCommand(
+    private val viewFrame: ViewFrame,
+) : Command("gamemode") {
     private val gamemodeArg: Argument<GameMode> =
-        ArgumentType.Enum("gameMode", GameMode::class.java)
+        ArgumentType
+            .Enum("gameMode", GameMode::class.java)
             .setSuggestionCallback { _, _, suggestion ->
                 for (gameMode in GameMode.entries) {
                     suggestion.addEntry(SuggestionEntry(gameMode.name.lowercase()))

--- a/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/command/IFExampleCommand.kt
+++ b/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/command/IFExampleCommand.kt
@@ -12,7 +12,9 @@ import net.minestom.server.command.builder.arguments.ArgumentType
 import net.minestom.server.command.builder.suggestion.SuggestionEntry
 import net.minestom.server.entity.Player
 
-class IFExampleCommand(private val viewFrame: ViewFrame) : Command("ifexample") {
+class IFExampleCommand(
+    private val viewFrame: ViewFrame,
+) : Command("ifexample") {
     private val availableViews =
         mapOf(
             "failing" to Failing::class.java,

--- a/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/view/Failing.kt
+++ b/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/view/Failing.kt
@@ -21,7 +21,8 @@ class Failing : View() {
         }
 
     override fun onFirstRender(render: RenderContext) {
-        render.layoutSlot('R')
+        render
+            .layoutSlot('R')
             .onRender { ctx: SlotRenderContext ->
                 if (state[ctx] == 0) {
                     ctx.item =
@@ -32,13 +33,13 @@ class Failing : View() {
                 } else {
                     throw IllegalStateException("This item cannot be rendered")
                 }
-            }
-            .onClick { ctx: SlotClickContext ->
+            }.onClick { ctx: SlotClickContext ->
                 state[1] = ctx
                 ctx.update()
             }
 
-        render.layoutSlot('C', displayItem(Material.STONE, "Click me and I will fail"))
+        render
+            .layoutSlot('C', displayItem(Material.STONE, "Click me and I will fail"))
             .onClick { _ ->
                 throw IllegalStateException("This is a failing inventory")
             }

--- a/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/view/ScheduledView.kt
+++ b/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/view/ScheduledView.kt
@@ -25,12 +25,14 @@ class ScheduledView : View() {
         }
 
     override fun onFirstRender(render: RenderContext) {
-        render.layoutSlot('C')
+        render
+            .layoutSlot('C')
             .onRender {
                 it.item = ExampleUtil.displayItem(Material.STONE, counter.increment(it).toString())
             }
 
-        render.layoutSlot('B', ExampleUtil.displayItem(Material.PAPER, "Back"))
+        render
+            .layoutSlot('B', ExampleUtil.displayItem(Material.PAPER, "Back"))
             .displayIf(Context::canBack)
             .onClick(SlotClickContext::back)
     }

--- a/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/view/SimplePagination.kt
+++ b/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/view/SimplePagination.kt
@@ -42,11 +42,13 @@ class SimplePagination : View() {
     override fun onFirstRender(render: RenderContext) {
         val previousItem = displayItem(Material.ARROW, "Previous")
         val nextItem = displayItem(Material.ARROW, "Next")
-        render.layoutSlot('P', previousItem)
+        render
+            .layoutSlot('P', previousItem)
             .displayIf({ ctx -> state[ctx].canBack() })
             .updateOnStateChange(state)
             .onClick { ctx: SlotClickContext -> state[ctx].back() }
-        render.layoutSlot('N', nextItem)
+        render
+            .layoutSlot('N', nextItem)
             .displayIf({ ctx -> state[ctx].canAdvance() })
             .updateOnStateChange(state)
             .onClick { ctx: SlotClickContext -> state[ctx].advance() }

--- a/examples/paper/build.gradle.kts
+++ b/examples/paper/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 
 tasks.shadowJar {
     archiveBaseName.set("inventory-framework-example")
-    archiveAppendix.set("bukkit")
+    archiveAppendix.set("paper")
 
     dependencies {
         exclude {
@@ -25,7 +25,7 @@ tasks.shadowJar {
 
 tasks.runServer {
     jvmArgs("-Dme.devnatan.inventoryframework.debug=true")
-    minecraftVersion("1.21.3")
+    minecraftVersion("1.21.4")
 }
 
 bukkit {
@@ -37,9 +37,8 @@ bukkit {
     apiVersion = "1.20"
     authors = listOf("SaiintBrisson", "DevNatan", "sasuked", "nicolube")
     commands {
-        create("ifexample") {
+        register("ifexample") {
             description = "This is a test command!"
-            permission = "ifexample.run"
             usage = "Opens example views"
         }
     }

--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/SamplePlugin.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/SamplePlugin.java
@@ -4,6 +4,7 @@ import me.devnatan.inventoryframework.AnvilInputFeature;
 import me.devnatan.inventoryframework.ViewFrame;
 import me.devnatan.inventoryframework.runtime.commands.IFExampleCommandExecutor;
 import me.devnatan.inventoryframework.runtime.view.AnvilInputSample;
+import me.devnatan.inventoryframework.runtime.view.AutoUpdate;
 import me.devnatan.inventoryframework.runtime.view.Failing;
 import me.devnatan.inventoryframework.runtime.view.SimplePagination;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -12,9 +13,10 @@ public class SamplePlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
+		System.out.println("ligoo");
         ViewFrame viewFrame = ViewFrame.create(this)
                 .install(AnvilInputFeature.AnvilInput)
-                .with(new AnvilInputSample(), new Failing(), new SimplePagination())
+                .with(new AnvilInputSample(), new Failing(), new SimplePagination(), new AutoUpdate())
                 .register();
 
         getCommand("ifexample").setExecutor(new IFExampleCommandExecutor(viewFrame));

--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/SamplePlugin.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/SamplePlugin.java
@@ -13,7 +13,7 @@ public class SamplePlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
-		System.out.println("ligoo");
+        System.out.println("ligoo");
         ViewFrame viewFrame = ViewFrame.create(this)
                 .install(AnvilInputFeature.AnvilInput)
                 .with(new AnvilInputSample(), new Failing(), new SimplePagination(), new AutoUpdate())

--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/commands/IFExampleCommandExecutor.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/commands/IFExampleCommandExecutor.java
@@ -2,6 +2,7 @@ package me.devnatan.inventoryframework.runtime.commands;
 
 import me.devnatan.inventoryframework.ViewFrame;
 import me.devnatan.inventoryframework.runtime.view.AnvilInputSample;
+import me.devnatan.inventoryframework.runtime.view.AutoUpdate;
 import me.devnatan.inventoryframework.runtime.view.Failing;
 import me.devnatan.inventoryframework.runtime.view.SimplePagination;
 import org.bukkit.command.Command;
@@ -33,7 +34,7 @@ public class IFExampleCommandExecutor implements CommandExecutor {
 
         if (strings.length == 0) {
             commandSender.sendMessage("Usage: /ifexample <view>");
-            commandSender.sendMessage("Available views: anvil, failing, simple-pagination");
+            commandSender.sendMessage("Available views: anvil, failing, simple-pagination, auto-update");
             return false;
         }
 
@@ -54,7 +55,12 @@ public class IFExampleCommandExecutor implements CommandExecutor {
             return true;
         }
 
+		if (view.equalsIgnoreCase("auto-update")) {
+			viewFrame.open(AutoUpdate.class, player);
+			return true;
+		}
+
         commandSender.sendMessage("Unknown view: " + view);
-        return false;
+        return true;
     }
 }

--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/commands/IFExampleCommandExecutor.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/commands/IFExampleCommandExecutor.java
@@ -55,10 +55,10 @@ public class IFExampleCommandExecutor implements CommandExecutor {
             return true;
         }
 
-		if (view.equalsIgnoreCase("auto-update")) {
-			viewFrame.open(AutoUpdate.class, player);
-			return true;
-		}
+        if (view.equalsIgnoreCase("auto-update")) {
+            viewFrame.open(AutoUpdate.class, player);
+            return true;
+        }
 
         commandSender.sendMessage("Unknown view: " + view);
         return true;

--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/AutoUpdate.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/AutoUpdate.java
@@ -1,0 +1,37 @@
+package me.devnatan.inventoryframework.runtime.view;
+
+import me.devnatan.inventoryframework.View;
+import me.devnatan.inventoryframework.ViewConfigBuilder;
+import me.devnatan.inventoryframework.component.Pagination;
+import me.devnatan.inventoryframework.context.Context;
+import me.devnatan.inventoryframework.context.RenderContext;
+import me.devnatan.inventoryframework.runtime.ExampleUtil;
+import me.devnatan.inventoryframework.state.MutableIntState;
+import me.devnatan.inventoryframework.state.State;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+public class AutoUpdate extends View {
+
+	private final MutableIntState countState = mutableState(0);
+
+    @Override
+    public void onInit(@NotNull ViewConfigBuilder config) {
+        config.cancelOnClick()
+			.title("Auto update (?)")
+			.scheduleUpdate(10);
+    }
+
+	@Override
+	public void onFirstRender(@NotNull RenderContext render) {
+		render.slot(1, new ItemStack(Material.DIAMOND))
+			.onClick(click -> click.openForPlayer(SimplePagination.class));
+	}
+
+	@Override
+	public void onUpdate(@NotNull Context update) {
+		final int count = countState.increment(update);
+		update.updateTitleForPlayer("Auto update (" + count + ")");
+	}
+}

--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/AutoUpdate.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/AutoUpdate.java
@@ -2,36 +2,30 @@ package me.devnatan.inventoryframework.runtime.view;
 
 import me.devnatan.inventoryframework.View;
 import me.devnatan.inventoryframework.ViewConfigBuilder;
-import me.devnatan.inventoryframework.component.Pagination;
 import me.devnatan.inventoryframework.context.Context;
 import me.devnatan.inventoryframework.context.RenderContext;
-import me.devnatan.inventoryframework.runtime.ExampleUtil;
 import me.devnatan.inventoryframework.state.MutableIntState;
-import me.devnatan.inventoryframework.state.State;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 public class AutoUpdate extends View {
 
-	private final MutableIntState countState = mutableState(0);
+    private final MutableIntState countState = mutableState(0);
 
     @Override
     public void onInit(@NotNull ViewConfigBuilder config) {
-        config.cancelOnClick()
-			.title("Auto update (?)")
-			.scheduleUpdate(10);
+        config.cancelOnClick().title("Auto update (?)").scheduleUpdate(10);
     }
 
-	@Override
-	public void onFirstRender(@NotNull RenderContext render) {
-		render.slot(1, new ItemStack(Material.DIAMOND))
-			.onClick(click -> click.openForPlayer(SimplePagination.class));
-	}
+    @Override
+    public void onFirstRender(@NotNull RenderContext render) {
+        render.slot(1, new ItemStack(Material.DIAMOND)).onClick(click -> click.openForPlayer(SimplePagination.class));
+    }
 
-	@Override
-	public void onUpdate(@NotNull Context update) {
-		final int count = countState.increment(update);
-		update.updateTitleForPlayer("Auto update (" + count + ")");
-	}
+    @Override
+    public void onUpdate(@NotNull Context update) {
+        final int count = countState.increment(update);
+        update.updateTitleForPlayer("Auto update (" + count + ")");
+    }
 }

--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/SimplePagination.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/SimplePagination.java
@@ -3,6 +3,7 @@ package me.devnatan.inventoryframework.runtime.view;
 import me.devnatan.inventoryframework.View;
 import me.devnatan.inventoryframework.ViewConfigBuilder;
 import me.devnatan.inventoryframework.component.Pagination;
+import me.devnatan.inventoryframework.context.Context;
 import me.devnatan.inventoryframework.context.RenderContext;
 import me.devnatan.inventoryframework.runtime.ExampleUtil;
 import me.devnatan.inventoryframework.state.State;
@@ -40,5 +41,9 @@ public class SimplePagination extends View {
                 .displayIf(() -> state.get(render).canAdvance())
                 .updateOnStateChange(state)
                 .onClick((ctx) -> state.get(ctx).advance());
+
+		render.lastSlot(new ItemStack(Material.ARROW))
+			.displayIf(Context::canBack)
+			.onClick(Context::back);
     }
 }

--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/SimplePagination.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/SimplePagination.java
@@ -42,8 +42,8 @@ public class SimplePagination extends View {
                 .updateOnStateChange(state)
                 .onClick((ctx) -> state.get(ctx).advance());
 
-		render.lastSlot(new ItemStack(Material.ARROW))
-			.displayIf(Context::canBack)
-			.onClick(Context::back);
+        render.lastSlot(new ItemStack(Material.ARROW))
+                .displayIf(Context::canBack)
+                .onClick(Context::back);
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ adventure-api = "4.19.0"
 kotlin = "2.1.0"
 plugin-shadowjar = "8.3.6"
 plugin-spotless = "7.0.2"
-plugin-bukkit = "0.6.0"
+plugin-bukkit = "0.7.1"
 minestom = "87f6524aeb"
 
 [libraries.spigot]
@@ -51,5 +51,5 @@ version.ref = "minestom"
 shadowjar = { id = "com.gradleup.shadow", version.ref = "plugin-shadowjar" }
 spotless = { id = "com.diffplug.spotless", version.ref = "plugin-spotless" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-bukkit = { id = "net.minecrell.plugin-yml.bukkit", version.ref = "plugin-bukkit" }
+bukkit = { id = "de.eldoria.plugin-yml.bukkit", version.ref = "plugin-bukkit" }
 run-paper = { id = "xyz.jpenilla.run-paper", version =  "2.3.1" }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/Viewer.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/Viewer.java
@@ -43,13 +43,13 @@ public interface Viewer {
     @NotNull
     IFRenderContext getActiveContext();
 
-	/**
-	 * <b><i> This is an internal inventory-framework API that should not be used from outside of
-	 * this library. No compatibility guarantees are provided. </i></b>
-	 */
-	@ApiStatus.Internal
-	@NotNull
-	IFRenderContext getCurrentContext();
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    @NotNull
+    IFRenderContext getCurrentContext();
 
     /**
      * <b><i> This is an internal inventory-framework API that should not be used from outside of

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/Viewer.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/Viewer.java
@@ -43,6 +43,14 @@ public interface Viewer {
     @NotNull
     IFRenderContext getActiveContext();
 
+	/**
+	 * <b><i> This is an internal inventory-framework API that should not be used from outside of
+	 * this library. No compatibility guarantees are provided. </i></b>
+	 */
+	@ApiStatus.Internal
+	@NotNull
+	IFRenderContext getCurrentContext();
+
     /**
      * <b><i> This is an internal inventory-framework API that should not be used from outside of
      * this library. No compatibility guarantees are provided. </i></b>
@@ -84,14 +92,14 @@ public interface Viewer {
      * this library. No compatibility guarantees are provided. </i></b>
      */
     @ApiStatus.Internal
-    boolean isTransitioning();
+    boolean isSwitching();
 
     /**
      * <b><i> This is an internal inventory-framework API that should not be used from outside of
      * this library. No compatibility guarantees are provided. </i></b>
      */
     @ApiStatus.Internal
-    void setTransitioning(boolean transitioning);
+    void setSwitching(boolean switching);
 
     /**
      * <b><i> This is an internal inventory-framework API that should not be used from outside of
@@ -106,13 +114,6 @@ public interface Viewer {
      */
     @ApiStatus.Internal
     void setPreviousContext(IFRenderContext context);
-
-    /**
-     * <b><i> This is an internal inventory-framework API that should not be used from outside of
-     * this library. No compatibility guarantees are provided. </i></b>
-     */
-    @ApiStatus.Internal
-    void unsetPreviousContext();
 
     /**
      * <b><i> This is an internal inventory-framework API that should not be used from outside of

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/pipeline/Pipeline.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/pipeline/Pipeline.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
 /**
@@ -99,7 +99,7 @@ public final class Pipeline<S> {
         interceptors.computeIfAbsent(phase, $ -> new ArrayList<>()).remove(interceptor);
     }
 
-    public void execute(@Nullable S subject) {
+    public void execute(S subject) {
         final List<PipelineInterceptor<S>> pipelineInterceptors = new LinkedList<>();
         for (final PipelinePhase phase : _phases) {
             final List<PipelineInterceptor<S>> interceptors = this.interceptors.get(phase);
@@ -113,9 +113,9 @@ public final class Pipeline<S> {
     }
 
     @TestOnly
-    public void execute(@NotNull PipelinePhase phase, @Nullable S subject) {
+    public void execute(PipelinePhase phase, S subject) {
         final PipelineContext<S> context =
                 new PipelineContext<>(phase, interceptors.getOrDefault(phase, Collections.emptyList()));
-        context.execute(subject);
+		context.execute(subject);
     }
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/pipeline/Pipeline.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/pipeline/Pipeline.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
 
@@ -116,6 +115,6 @@ public final class Pipeline<S> {
     public void execute(PipelinePhase phase, S subject) {
         final PipelineContext<S> context =
                 new PipelineContext<>(phase, interceptors.getOrDefault(phase, Collections.emptyList()));
-		context.execute(subject);
+        context.execute(subject);
     }
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/pipeline/StandardPipelinePhases.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/pipeline/StandardPipelinePhases.java
@@ -1,6 +1,7 @@
 package me.devnatan.inventoryframework.pipeline;
 
 import me.devnatan.inventoryframework.RootView;
+import me.devnatan.inventoryframework.Viewer;
 import me.devnatan.inventoryframework.context.IFCloseContext;
 import me.devnatan.inventoryframework.context.IFConfinedContext;
 import me.devnatan.inventoryframework.context.IFContext;
@@ -59,13 +60,9 @@ public final class StandardPipelinePhases {
      */
     public static final PipelinePhase INVALIDATION = new PipelinePhase("invalidation");
 
+	/** Called when a viewer is added to a context with {@link IFContext#addViewer(Viewer)}. */
     public static final PipelinePhase VIEWER_ADDED = new PipelinePhase("viewer-added");
 
+	/** Called when a viewer is removed from a context with {@link IFContext#removeViewer(Viewer)}. */
     public static final PipelinePhase VIEWER_REMOVED = new PipelinePhase("viewer-removed");
-
-    /**
-     * Called during layout resolution phase before {@link #FIRST_RENDER} phase.
-     * In this pipeline phase the pipeline interceptor subject is a {@link IFRenderContext}.
-     */
-    //    public static final PipelinePhase LAYOUT_RESOLUTION = new PipelinePhase("layout-resolution");
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/pipeline/StandardPipelinePhases.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/pipeline/StandardPipelinePhases.java
@@ -60,9 +60,9 @@ public final class StandardPipelinePhases {
      */
     public static final PipelinePhase INVALIDATION = new PipelinePhase("invalidation");
 
-	/** Called when a viewer is added to a context with {@link IFContext#addViewer(Viewer)}. */
+    /** Called when a viewer is added to a context with {@link IFContext#addViewer(Viewer)}. */
     public static final PipelinePhase VIEWER_ADDED = new PipelinePhase("viewer-added");
 
-	/** Called when a viewer is removed from a context with {@link IFContext#removeViewer(Viewer)}. */
+    /** Called when a viewer is removed from a context with {@link IFContext#removeViewer(Viewer)}. */
     public static final PipelinePhase VIEWER_REMOVED = new PipelinePhase("viewer-removed");
 }

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/DefaultRootView.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/DefaultRootView.java
@@ -2,14 +2,7 @@ package me.devnatan.inventoryframework;
 
 import static java.util.Collections.newSetFromMap;
 import static java.util.Collections.synchronizedMap;
-import static me.devnatan.inventoryframework.pipeline.StandardPipelinePhases.CLICK;
-import static me.devnatan.inventoryframework.pipeline.StandardPipelinePhases.CLOSE;
-import static me.devnatan.inventoryframework.pipeline.StandardPipelinePhases.FIRST_RENDER;
-import static me.devnatan.inventoryframework.pipeline.StandardPipelinePhases.INIT;
-import static me.devnatan.inventoryframework.pipeline.StandardPipelinePhases.INVALIDATION;
-import static me.devnatan.inventoryframework.pipeline.StandardPipelinePhases.LAYOUT_RESOLUTION;
-import static me.devnatan.inventoryframework.pipeline.StandardPipelinePhases.OPEN;
-import static me.devnatan.inventoryframework.pipeline.StandardPipelinePhases.UPDATE;
+import static me.devnatan.inventoryframework.pipeline.StandardPipelinePhases.*;
 
 import java.util.*;
 import me.devnatan.inventoryframework.context.IFContext;
@@ -26,7 +19,7 @@ public abstract class DefaultRootView implements RootView {
     private final UUID id = UUID.randomUUID();
     private ViewConfig config;
     private final Pipeline<VirtualView> pipeline =
-            new Pipeline<>(INIT, OPEN, LAYOUT_RESOLUTION, FIRST_RENDER, UPDATE, CLICK, CLOSE, INVALIDATION);
+            new Pipeline<>(INIT, OPEN, VIEWER_ADDED, LAYOUT_RESOLUTION, FIRST_RENDER, UPDATE, CLICK, VIEWER_REMOVED, CLOSE, INVALIDATION);
     private final Set<IFContext> contexts = newSetFromMap(synchronizedMap(new HashMap<>()));
     final StateRegistry stateRegistry = new StateRegistry();
     private Job scheduledUpdateJob;

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/DefaultRootView.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/DefaultRootView.java
@@ -18,8 +18,17 @@ public abstract class DefaultRootView implements RootView {
 
     private final UUID id = UUID.randomUUID();
     private ViewConfig config;
-    private final Pipeline<VirtualView> pipeline =
-            new Pipeline<>(INIT, OPEN, VIEWER_ADDED, LAYOUT_RESOLUTION, FIRST_RENDER, UPDATE, CLICK, VIEWER_REMOVED, CLOSE, INVALIDATION);
+    private final Pipeline<VirtualView> pipeline = new Pipeline<>(
+            INIT,
+            OPEN,
+            VIEWER_ADDED,
+            LAYOUT_RESOLUTION,
+            FIRST_RENDER,
+            UPDATE,
+            CLICK,
+            VIEWER_REMOVED,
+            CLOSE,
+            INVALIDATION);
     private final Set<IFContext> contexts = newSetFromMap(synchronizedMap(new HashMap<>()));
     final StateRegistry stateRegistry = new StateRegistry();
     private Job scheduledUpdateJob;

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/context/AbstractIFContext.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/context/AbstractIFContext.java
@@ -45,8 +45,10 @@ abstract class AbstractIFContext extends DefaultStateValueHost implements IFCont
             getIndexedViewers().put(viewer.getId(), viewer);
         }
 
-        IFDebug.debug(
-                "Viewer %s added to %s", viewer.getId(), getRoot().getClass().getName());
+		getRoot().getPipeline().execute(StandardPipelinePhases.VIEWER_ADDED, this);
+
+		IFDebug.debug(
+                "Viewer %s added to [%s] %s", viewer.getId(), getClass().getSimpleName(), getRoot().getClass().getName());
     }
 
     @Override
@@ -54,9 +56,14 @@ abstract class AbstractIFContext extends DefaultStateValueHost implements IFCont
         synchronized (getIndexedViewers()) {
             getIndexedViewers().remove(viewer.getId());
         }
-        IFDebug.debug(
-                "Viewer %s removed from %s",
-                viewer.getId(), getRoot().getClass().getName());
+
+		getRoot().getPipeline().execute(StandardPipelinePhases.VIEWER_REMOVED, this);
+
+		IFDebug.debug(
+                "Viewer %s removed from [%s] %s",
+                viewer.getId(),
+				getClass().getSimpleName(),
+				getRoot().getClass().getName());
     }
 
     @Override

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/context/AbstractIFContext.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/context/AbstractIFContext.java
@@ -45,10 +45,11 @@ abstract class AbstractIFContext extends DefaultStateValueHost implements IFCont
             getIndexedViewers().put(viewer.getId(), viewer);
         }
 
-		getRoot().getPipeline().execute(StandardPipelinePhases.VIEWER_ADDED, this);
+        getRoot().getPipeline().execute(StandardPipelinePhases.VIEWER_ADDED, this);
 
-		IFDebug.debug(
-                "Viewer %s added to [%s] %s", viewer.getId(), getClass().getSimpleName(), getRoot().getClass().getName());
+        IFDebug.debug(
+                "Viewer %s added to [%s] %s",
+                viewer.getId(), getClass().getSimpleName(), getRoot().getClass().getName());
     }
 
     @Override
@@ -57,13 +58,11 @@ abstract class AbstractIFContext extends DefaultStateValueHost implements IFCont
             getIndexedViewers().remove(viewer.getId());
         }
 
-		getRoot().getPipeline().execute(StandardPipelinePhases.VIEWER_REMOVED, this);
+        getRoot().getPipeline().execute(StandardPipelinePhases.VIEWER_REMOVED, this);
 
-		IFDebug.debug(
+        IFDebug.debug(
                 "Viewer %s removed from [%s] %s",
-                viewer.getId(),
-				getClass().getSimpleName(),
-				getRoot().getClass().getName());
+                viewer.getId(), getClass().getSimpleName(), getRoot().getClass().getName());
     }
 
     @Override

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/ScheduledUpdateStartInterceptor.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/ScheduledUpdateStartInterceptor.java
@@ -5,7 +5,6 @@ import java.util.List;
 import me.devnatan.inventoryframework.RootView;
 import me.devnatan.inventoryframework.VirtualView;
 import me.devnatan.inventoryframework.context.IFContext;
-import me.devnatan.inventoryframework.context.IFRenderContext;
 import me.devnatan.inventoryframework.internal.Job;
 
 public final class ScheduledUpdateStartInterceptor implements PipelineInterceptor<VirtualView> {
@@ -19,18 +18,18 @@ public final class ScheduledUpdateStartInterceptor implements PipelineIntercepto
         final long updateIntervalInTicks = context.getConfig().getUpdateIntervalInTicks();
 
         if (updateIntervalInTicks == 0) {
-			return;
-		}
+            return;
+        }
 
         if (root.getScheduledUpdateJob() != null && root.getScheduledUpdateJob().isStarted()) {
-			return;
-		}
+            return;
+        }
 
         final Job updateJob = root.getElementFactory().scheduleJobInterval(root, updateIntervalInTicks, () -> {
             final List<IFContext> contextList = new ArrayList<>(root.getInternalContexts());
             contextList.stream().filter(IFContext::isActive).forEach(IFContext::update);
         });
-		root.setScheduledUpdateJob(updateJob);
-		updateJob.start();
+        root.setScheduledUpdateJob(updateJob);
+        updateJob.start();
     }
 }

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/ScheduledUpdateStartInterceptor.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/ScheduledUpdateStartInterceptor.java
@@ -12,20 +12,25 @@ public final class ScheduledUpdateStartInterceptor implements PipelineIntercepto
 
     @Override
     public void intercept(PipelineContext<VirtualView> pipeline, VirtualView subject) {
-        if (!(subject instanceof IFRenderContext)) return;
+        if (pipeline.getPhase() != StandardPipelinePhases.VIEWER_ADDED) return;
 
         final IFContext context = (IFContext) subject;
         final RootView root = context.getRoot();
         final long updateIntervalInTicks = context.getConfig().getUpdateIntervalInTicks();
 
-        if (updateIntervalInTicks == 0) return;
-        if (root.getScheduledUpdateJob() != null && root.getScheduledUpdateJob().isStarted()) return;
+        if (updateIntervalInTicks == 0) {
+			return;
+		}
+
+        if (root.getScheduledUpdateJob() != null && root.getScheduledUpdateJob().isStarted()) {
+			return;
+		}
 
         final Job updateJob = root.getElementFactory().scheduleJobInterval(root, updateIntervalInTicks, () -> {
             final List<IFContext> contextList = new ArrayList<>(root.getInternalContexts());
             contextList.stream().filter(IFContext::isActive).forEach(IFContext::update);
         });
-        updateJob.start();
-        root.setScheduledUpdateJob(updateJob);
+		root.setScheduledUpdateJob(updateJob);
+		updateJob.start();
     }
 }

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/ScheduledUpdateStopInterceptor.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/ScheduledUpdateStopInterceptor.java
@@ -12,24 +12,24 @@ public final class ScheduledUpdateStopInterceptor implements PipelineInterceptor
         if (pipeline.getPhase() != StandardPipelinePhases.VIEWER_REMOVED) return;
 
         final IFCloseContext context = (IFCloseContext) subject;
-		final long updateIntervalInTicks = context.getConfig().getUpdateIntervalInTicks();
-		if (updateIntervalInTicks == 0) {
-			return;
-		}
+        final long updateIntervalInTicks = context.getConfig().getUpdateIntervalInTicks();
+        if (updateIntervalInTicks == 0) {
+            return;
+        }
 
-		final RootView root = context.getRoot();
+        final RootView root = context.getRoot();
         if (root.getScheduledUpdateJob() == null
                 || !root.getScheduledUpdateJob().isStarted()) {
-			return;
-		}
+            return;
+        }
 
         if (context.isCancelled() || !context.isActive()) {
-			return;
-		}
+            return;
+        }
 
         if (root.getInternalContexts().stream().filter(IFContext::isActive).count() > 1) {
-			return;
-		}
+            return;
+        }
 
         root.getScheduledUpdateJob().cancel();
     }

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/ScheduledUpdateStopInterceptor.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/ScheduledUpdateStopInterceptor.java
@@ -9,14 +9,27 @@ public final class ScheduledUpdateStopInterceptor implements PipelineInterceptor
 
     @Override
     public void intercept(PipelineContext<VirtualView> pipeline, VirtualView subject) {
-        if (!(subject instanceof IFCloseContext)) return;
+        if (pipeline.getPhase() != StandardPipelinePhases.VIEWER_REMOVED) return;
 
         final IFCloseContext context = (IFCloseContext) subject;
-        final RootView root = context.getRoot();
+		final long updateIntervalInTicks = context.getConfig().getUpdateIntervalInTicks();
+		if (updateIntervalInTicks == 0) {
+			return;
+		}
+
+		final RootView root = context.getRoot();
         if (root.getScheduledUpdateJob() == null
-                || !root.getScheduledUpdateJob().isStarted()) return;
-        if (context.isCancelled() || !context.isActive()) return;
-        if (root.getInternalContexts().stream().anyMatch(IFContext::isActive)) return;
+                || !root.getScheduledUpdateJob().isStarted()) {
+			return;
+		}
+
+        if (context.isCancelled() || !context.isActive()) {
+			return;
+		}
+
+        if (root.getInternalContexts().stream().filter(IFContext::isActive).count() > 1) {
+			return;
+		}
 
         root.getScheduledUpdateJob().cancel();
     }

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/BukkitViewer.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/BukkitViewer.java
@@ -31,16 +31,16 @@ public final class BukkitViewer implements Viewer {
         return activeContext;
     }
 
-	@Override
-	public @NotNull IFRenderContext getCurrentContext() {
-		IFRenderContext prevCtx = null;
-		if (isSwitching() && ((prevCtx = getPreviousContext()) == null))
-			throw new IllegalStateException("Previous context cannot be null when switching");
+    @Override
+    public @NotNull IFRenderContext getCurrentContext() {
+        IFRenderContext prevCtx = null;
+        if (isSwitching() && ((prevCtx = getPreviousContext()) == null))
+            throw new IllegalStateException("Previous context cannot be null when switching");
 
-		return prevCtx == null ? getActiveContext() : prevCtx;
-	}
+        return prevCtx == null ? getActiveContext() : prevCtx;
+    }
 
-	@Override
+    @Override
     public void setActiveContext(@NotNull IFRenderContext context) {
         this.activeContext = context;
     }
@@ -102,9 +102,9 @@ public final class BukkitViewer implements Viewer {
         return previousContexts.peekLast();
     }
 
-	@Override
+    @Override
     public void setPreviousContext(IFRenderContext previousContext) {
-		previousContexts.pollLast();
+        previousContexts.pollLast();
         previousContexts.add(previousContext);
     }
 

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/BukkitViewer.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/BukkitViewer.java
@@ -14,7 +14,7 @@ public final class BukkitViewer implements Viewer {
     private IFRenderContext activeContext;
     private Deque<IFRenderContext> previousContexts = new LinkedList<>();
     private long lastInteractionInMillis;
-    private boolean transitioning;
+    private boolean switching;
 
     public BukkitViewer(@NotNull Player player, IFRenderContext activeContext) {
         this.player = player;
@@ -31,7 +31,16 @@ public final class BukkitViewer implements Viewer {
         return activeContext;
     }
 
-    @Override
+	@Override
+	public @NotNull IFRenderContext getCurrentContext() {
+		IFRenderContext prevCtx = null;
+		if (isSwitching() && ((prevCtx = getPreviousContext()) == null))
+			throw new IllegalStateException("Previous context cannot be null when switching");
+
+		return prevCtx == null ? getActiveContext() : prevCtx;
+	}
+
+	@Override
     public void setActiveContext(@NotNull IFRenderContext context) {
         this.activeContext = context;
     }
@@ -79,13 +88,13 @@ public final class BukkitViewer implements Viewer {
     }
 
     @Override
-    public boolean isTransitioning() {
-        return transitioning;
+    public boolean isSwitching() {
+        return switching;
     }
 
     @Override
-    public void setTransitioning(boolean transitioning) {
-        this.transitioning = transitioning;
+    public void setSwitching(boolean switching) {
+        this.switching = switching;
     }
 
     @Override
@@ -93,14 +102,10 @@ public final class BukkitViewer implements Viewer {
         return previousContexts.peekLast();
     }
 
-    @Override
+	@Override
     public void setPreviousContext(IFRenderContext previousContext) {
+		previousContexts.pollLast();
         previousContexts.add(previousContext);
-    }
-
-    @Override
-    public void unsetPreviousContext() {
-        previousContexts.pollLast();
     }
 
     @Override
@@ -127,7 +132,7 @@ public final class BukkitViewer implements Viewer {
                 + "player=" + player
                 + ", selfContainer=" + selfContainer
                 + ", lastInteractionInMillis=" + lastInteractionInMillis
-                + ", isTransitioning=" + transitioning
+                + ", isTransitioning=" + switching
                 + "}";
     }
 }

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/IFInventoryListener.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/IFInventoryListener.java
@@ -18,6 +18,8 @@ import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.inventory.PlayerInventory;
 
+import java.util.Objects;
+
 final class IFInventoryListener implements Listener {
 
     private final ViewFrame viewFrame;
@@ -66,7 +68,7 @@ final class IFInventoryListener implements Listener {
         final Viewer viewer = viewFrame.getViewer(player);
         if (viewer == null) return;
 
-        final IFRenderContext context = viewer.getActiveContext();
+        final IFRenderContext context = viewer.getCurrentContext();
         final RootView root = context.getRoot();
         final IFCloseContext closeContext = root.getElementFactory().createCloseContext(viewer, context);
 

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/IFInventoryListener.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/IFInventoryListener.java
@@ -18,8 +18,6 @@ import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.inventory.PlayerInventory;
 
-import java.util.Objects;
-
 final class IFInventoryListener implements Listener {
 
     private final ViewFrame viewFrame;

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/internal/BukkitElementFactory.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/internal/BukkitElementFactory.java
@@ -144,8 +144,6 @@ public class BukkitElementFactory extends ElementFactory {
 
     @Override
     public Job scheduleJobInterval(@NotNull RootView root, long intervalInTicks, @NotNull Runnable execution) {
-        final View platformRoot = (View) root;
-        final ViewFrame platformFramework = (ViewFrame) platformRoot.getFramework();
-        return new BukkitTaskJobImpl(platformFramework.getOwner(), intervalInTicks, execution);
+        return new BukkitTaskJobImpl(((View) root).getFramework().getOwner(), intervalInTicks, execution);
     }
 }

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/runtime/thirdparty/ReflectionUtils.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/runtime/thirdparty/ReflectionUtils.java
@@ -216,7 +216,7 @@ public final class ReflectionUtils {
      * @since 4.0.0
      */
     public static boolean supports(int minorNumber) {
-		return MINOR_NUMBER >= minorNumber;
+        return MINOR_NUMBER >= minorNumber;
     }
 
     /**

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/runtime/thirdparty/ReflectionUtils.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/runtime/thirdparty/ReflectionUtils.java
@@ -216,7 +216,7 @@ public final class ReflectionUtils {
      * @since 4.0.0
      */
     public static boolean supports(int minorNumber) {
-        return MINOR_NUMBER >= minorNumber;
+		return MINOR_NUMBER >= minorNumber;
     }
 
     /**

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/MinestomViewer.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/MinestomViewer.kt
@@ -10,7 +10,13 @@ class MinestomViewer(val player: Player, private var activeContext: IFRenderCont
     private var selfContainer: ViewContainer? = null
     private val previousContexts: Deque<IFRenderContext> = LinkedList()
     private var lastInteractionInMillis: Long = 0
-    private var transitioning = false
+    private var switching = false
+
+    override fun getCurrentContext(): IFRenderContext = if (isSwitching()) {
+        getPreviousContext() ?: error("Previous context cannot be null when switching")
+    } else {
+        getActiveContext()
+    }
 
     override fun getActiveContext(): IFRenderContext {
         return activeContext!!
@@ -60,12 +66,12 @@ class MinestomViewer(val player: Player, private var activeContext: IFRenderCont
         return getLastInteractionInMillis() + configuredDelay >= System.currentTimeMillis()
     }
 
-    override fun isTransitioning(): Boolean {
-        return transitioning
+    override fun isSwitching(): Boolean {
+        return switching
     }
 
-    override fun setTransitioning(transitioning: Boolean) {
-        this.transitioning = transitioning
+    override fun setSwitching(switching: Boolean) {
+        this.switching = switching
     }
 
     override fun getPreviousContext(): IFRenderContext? {
@@ -73,11 +79,8 @@ class MinestomViewer(val player: Player, private var activeContext: IFRenderCont
     }
 
     override fun setPreviousContext(previousContext: IFRenderContext) {
-        previousContexts.add(previousContext)
-    }
-
-    override fun unsetPreviousContext() {
         previousContexts.pollLast()
+        previousContexts.add(previousContext)
     }
 
     override fun getPlatformInstance(): Any {
@@ -101,7 +104,7 @@ class MinestomViewer(val player: Player, private var activeContext: IFRenderCont
                 "player=" + player +
                 ", selfContainer=" + selfContainer +
                 ", lastInteractionInMillis=" + lastInteractionInMillis +
-                ", isTransitioning=" + transitioning +
+                ", isSwitching=" + switching +
                 "}"
         )
     }

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
@@ -211,11 +211,11 @@ public abstract class IFViewFrame<S extends IFViewFrame<S, V>, V extends Platfor
         return new EndlessContextInfo(context, view);
     }
 
-	/**
-	 * <b><i> This is an internal inventory-framework API that should not be used from outside of
-	 * this library. No compatibility guarantees are provided. </i></b>
-	 */
-	@ApiStatus.Internal
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
     public void addViewer(@NotNull Viewer viewer) {
         synchronized (viewerById) {
             viewerById.put(viewer.getId(), viewer);

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java
@@ -211,7 +211,12 @@ public abstract class IFViewFrame<S extends IFViewFrame<S, V>, V extends Platfor
         return new EndlessContextInfo(context, view);
     }
 
-    void addViewer(@NotNull Viewer viewer) {
+	/**
+	 * <b><i> This is an internal inventory-framework API that should not be used from outside of
+	 * this library. No compatibility guarantees are provided. </i></b>
+	 */
+	@ApiStatus.Internal
+    public void addViewer(@NotNull Viewer viewer) {
         synchronized (viewerById) {
             viewerById.put(viewer.getId(), viewer);
         }

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -328,8 +328,6 @@ public abstract class PlatformView<
         @SuppressWarnings("rawtypes")
         final PlatformView view = (PlatformView) context.getRoot();
         context.getViewers().forEach(viewer -> {
-            if (viewer.isTransitioning()) viewer.setActiveContext(context);
-            view.getFramework().addViewer(viewer);
             if (!context.getContainer().isProxied()) context.getContainer().open(viewer);
             viewer.setTransitioning(false);
         });

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -128,9 +128,9 @@ public abstract class PlatformView<
         if (targetContext == null) throw new IllegalArgumentException("Context not found: " + contextId);
         if (!targetContext.isActive()) throw new IllegalStateException("Invalidated");
 
-		viewer.setActiveContext(targetContext);
-		onViewerAdded((TContext) targetContext, (TViewer) viewer.getPlatformInstance(), initialData);
-		targetContext.addViewer(viewer);
+        viewer.setActiveContext(targetContext);
+        onViewerAdded((TContext) targetContext, (TViewer) viewer.getPlatformInstance(), initialData);
+        targetContext.addViewer(viewer);
         getFramework().addViewer(viewer);
         viewer.open(targetContext.getContainer());
     }
@@ -147,9 +147,9 @@ public abstract class PlatformView<
             @NotNull Class<? extends PlatformView> target, @NotNull IFRenderContext origin, Object initialData) {
         final List<Viewer> viewers = origin.getViewers();
         viewers.forEach(viewer -> {
-			viewer.setSwitching(true);
-			viewer.setPreviousContext(origin);
-		});
+            viewer.setSwitching(true);
+            viewer.setPreviousContext(origin);
+        });
         getFramework().getRegisteredViewByType(target).open(viewers, initialData);
     }
 
@@ -164,10 +164,10 @@ public abstract class PlatformView<
             @NotNull IFRenderContext origin,
             @NotNull Viewer viewer,
             Object initialData) {
-		viewer.setPreviousContext(origin);
-		viewer.setSwitching(true);
+        viewer.setPreviousContext(origin);
+        viewer.setSwitching(true);
         getFramework().getRegisteredViewByType(target).open(Collections.singletonList(viewer), initialData);
-		viewer.setSwitching(false);
+        viewer.setSwitching(false);
     }
 
     /**
@@ -188,8 +188,8 @@ public abstract class PlatformView<
     public final void back(@NotNull Viewer viewer, Object initialData) {
         final IFRenderContext active = viewer.getActiveContext();
         final IFRenderContext target = viewer.getPreviousContext();
-		viewer.setPreviousContext(active);
-		viewer.setSwitching(true);
+        viewer.setPreviousContext(active);
+        viewer.setSwitching(true);
 
         if (initialData != null) {
             for (final Map.Entry<Long, StateValue> entry :
@@ -202,24 +202,23 @@ public abstract class PlatformView<
             target.setInitialData(initialData);
         }
 
-		viewer.setActiveContext(target);
+        viewer.setActiveContext(target);
 
-		final PlatformView root = (PlatformView) target.getRoot();
-		root.onViewerAdded(target, viewer, initialData);
-		target.addViewer(viewer);
+        final PlatformView root = (PlatformView) target.getRoot();
+        root.onViewerAdded(target, viewer, initialData);
+        target.addViewer(viewer);
 
-		if (!root.hasContext(target.getId())) {
-			target.setActive(true);
-			root.addContext(target);
-		}
+        if (!root.hasContext(target.getId())) {
+            target.setActive(true);
+            root.addContext(target);
+        }
 
-		if (target.getViewers().size() == 1)
-			target.getContainer().open(viewer);
-		else {
-			root.renderContext(target);
-		}
+        if (target.getViewers().size() == 1) target.getContainer().open(viewer);
+        else {
+            root.renderContext(target);
+        }
 
-		root.onResume(active, target);
+        root.onResume(active, target);
         viewer.setSwitching(false);
     }
     // endregion
@@ -288,7 +287,9 @@ public abstract class PlatformView<
         synchronized (getInternalContexts()) {
             getInternalContexts().add(context);
         }
-        IFDebug.debug("Context %s added to [%s] %s", context.getId(), context.getClass().getSimpleName(), getClass().getName());
+        IFDebug.debug(
+                "Context %s added to [%s] %s",
+                context.getId(), context.getClass().getSimpleName(), getClass().getName());
     }
 
     /**

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -202,8 +202,6 @@ public abstract class PlatformView<
             target.setInitialData(initialData);
         }
 
-        viewer.setActiveContext(target);
-
         final PlatformView root = (PlatformView) target.getRoot();
         root.onViewerAdded(target, viewer, initialData);
         target.addViewer(viewer);
@@ -218,6 +216,7 @@ public abstract class PlatformView<
             root.renderContext(target);
         }
 
+		viewer.setActiveContext(target);
         root.onResume(active, target);
         viewer.setSwitching(false);
     }

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformConfinedContext.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformConfinedContext.java
@@ -36,7 +36,6 @@ public abstract class PlatformConfinedContext extends PlatformContext implements
         final Object data =
                 getConfig().isTransitiveInitialData() && mergeInitialData ? mergeInitialData(initialData) : initialData;
         getRoot().navigateTo(other, (IFRenderContext) this, getViewer(), data);
-
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformConfinedContext.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformConfinedContext.java
@@ -36,6 +36,7 @@ public abstract class PlatformConfinedContext extends PlatformContext implements
         final Object data =
                 getConfig().isTransitiveInitialData() && mergeInitialData ? mergeInitialData(initialData) : initialData;
         getRoot().navigateTo(other, (IFRenderContext) this, getViewer(), data);
+
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/pipeline/ContextInvalidationOnCloseInterceptor.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/pipeline/ContextInvalidationOnCloseInterceptor.java
@@ -22,8 +22,6 @@ public final class ContextInvalidationOnCloseInterceptor implements PipelineInte
 
         final PlatformView root = (PlatformView) context.getRoot();
         final Viewer viewer = context.getViewer();
-        root.onViewerRemoved(context.getParent(), viewer.getPlatformInstance());
-        root.getPipeline().execute(StandardPipelinePhases.VIEWER_REMOVED, subject);
         root.removeAndTryInvalidateContext(viewer, context);
     }
 }

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/pipeline/PlatformOpenInterceptor.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/pipeline/PlatformOpenInterceptor.java
@@ -54,7 +54,6 @@ public final class PlatformOpenInterceptor implements PipelineInterceptor<Virtua
         root.renderContext(render);
     }
 
-    @SuppressWarnings("unchecked")
     IFRenderContext createRenderContext(IFOpenContext openContext) {
         @SuppressWarnings("rawtypes")
         final PlatformView root = (PlatformView) openContext.getRoot();
@@ -86,15 +85,26 @@ public final class PlatformOpenInterceptor implements PipelineInterceptor<Virtua
         renderContext.setEndless(openContext.isEndless());
         openContext.getStateValues().forEach(renderContext::initializeState);
 
-        for (final Viewer viewer : openContext.getIndexedViewers().values()) {
-            if (!viewer.isTransitioning()) viewer.setActiveContext(renderContext);
-            // TODO Pass viewer object as parameter instead
-            root.onViewerAdded(renderContext, viewer.getPlatformInstance(), renderContext.getInitialData());
-            root.getPipeline().execute(StandardPipelinePhases.VIEWER_ADDED, renderContext);
-            renderContext.addViewer(viewer);
+        for (final Viewer viewer : renderContext.getIndexedViewers().values()) {
+			setupViewer(viewer, renderContext, root);
         }
+
+		final Viewer viewer = renderContext.getViewer();
+		if (viewer != null)
+			setupViewer(viewer, renderContext, root);
 
         renderContext.setActive(true);
         return renderContext;
     }
+
+	private void setupViewer(Viewer viewer, IFRenderContext context, PlatformView root) {
+		viewer.setActiveContext(context);
+
+		if (!viewer.isSwitching())
+			root.getFramework().addViewer(viewer);
+
+		// TODO Pass viewer object as parameter instead
+		root.onViewerAdded(context, viewer.getPlatformInstance(), context.getInitialData());
+		context.addViewer(viewer);
+	}
 }

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/pipeline/PlatformOpenInterceptor.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/pipeline/PlatformOpenInterceptor.java
@@ -86,25 +86,23 @@ public final class PlatformOpenInterceptor implements PipelineInterceptor<Virtua
         openContext.getStateValues().forEach(renderContext::initializeState);
 
         for (final Viewer viewer : renderContext.getIndexedViewers().values()) {
-			setupViewer(viewer, renderContext, root);
+            setupViewer(viewer, renderContext, root);
         }
 
-		final Viewer viewer = renderContext.getViewer();
-		if (viewer != null)
-			setupViewer(viewer, renderContext, root);
+        final Viewer viewer = renderContext.getViewer();
+        if (viewer != null) setupViewer(viewer, renderContext, root);
 
         renderContext.setActive(true);
         return renderContext;
     }
 
-	private void setupViewer(Viewer viewer, IFRenderContext context, PlatformView root) {
-		viewer.setActiveContext(context);
+    private void setupViewer(Viewer viewer, IFRenderContext context, PlatformView root) {
+        viewer.setActiveContext(context);
 
-		if (!viewer.isSwitching())
-			root.getFramework().addViewer(viewer);
+        if (!viewer.isSwitching()) root.getFramework().addViewer(viewer);
 
-		// TODO Pass viewer object as parameter instead
-		root.onViewerAdded(context, viewer.getPlatformInstance(), context.getInitialData());
-		context.addViewer(viewer);
-	}
+        // TODO Pass viewer object as parameter instead
+        root.onViewerAdded(context, viewer.getPlatformInstance(), context.getInitialData());
+        context.addViewer(viewer);
+    }
 }


### PR DESCRIPTION
I noticed that in samples, debugs we're displaying the wrong values for "Viewer added to..." and "Viewer removed from...", when switching contexts the context shown in "Viewer added" and "Viewer removed" debugs were the same (which is wrong);

* Added a constraint to require that calls to `getPreviousContext` must ensure that `isSwitching` to true in Viewer API
* Fixed `PlatformView#onViewerAdded` and pipeline `VIEWER_ADDED`/`VIEWER_REMOVED` calls order.
* Fixed the target context when switching from a context to another. Now "current context" is correctly set to the previous context when switching from a context to another and only set to the next one when it is fully rendered and ready to use.
* Introduced Viewer API `getCurrentContext` that ensures context consistency when switching from a context to another.
* Fixed `isSwitching` reset once a player is switched successfully to the next context.
* Now `onViewerAdded` is also called when switching back to a context (onViewerAdded -> onResume).

With all the changes, when switching back to a context (`context.back()`) state values of that context will be kept. I'll address it in the next PR. For now you need to manually reset (if you want) via `onResume`.

Fixes https://github.com/DevNatan/inventory-framework/issues/696; Fixes https://github.com/DevNatan/inventory-framework/issues/658; Fixes https://github.com/DevNatan/inventory-framework/issues/657; Fixes https://github.com/DevNatan/inventory-framework/issues/649; Fixes https://github.com/DevNatan/inventory-framework/issues/647; Fixes https://github.com/DevNatan/inventory-framework/issues/383
