### PR TITLE
Refactor Reflections & move supports to McVersion to make it avalibe …

### DIFF
--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/SimplePagination.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/SimplePagination.java
@@ -36,11 +36,19 @@ public class SimplePagination extends View {
         render.layoutSlot('P', previousItem)
                 .displayIf(() -> state.get(render).canBack())
                 .updateOnStateChange(state)
-                .onClick((ctx) -> state.get(ctx).back());
+                .onClick((ctx) -> {
+                    Pagination pagination = state.get(ctx);
+                    pagination.back();
+                    ctx.updateTitleForPlayer("Simple Pagination (" + pagination.currentPage() + ")");
+                });
         render.layoutSlot('N', nextItem)
                 .displayIf(() -> state.get(render).canAdvance())
                 .updateOnStateChange(state)
-                .onClick((ctx) -> state.get(ctx).advance());
+                .onClick((ctx) -> {
+                    Pagination pagination = state.get(ctx);
+                    pagination.advance();
+                    ctx.updateTitleForPlayer("Simple Pagination (" + pagination.currentPage() + ")");
+                });
 
         render.lastSlot(new ItemStack(Material.ARROW))
                 .displayIf(Context::canBack)

--- a/inventory-framework-anvil-input/src/main/java/me/devnatan/inventoryframework/AnvilInputNMS.java
+++ b/inventory-framework-anvil-input/src/main/java/me/devnatan/inventoryframework/AnvilInputNMS.java
@@ -1,7 +1,6 @@
 package me.devnatan.inventoryframework;
 
 import static me.devnatan.inventoryframework.runtime.thirdparty.InventoryUpdate.CONTAINER;
-import static me.devnatan.inventoryframework.runtime.thirdparty.InventoryUpdate.ENTITY_PLAYER;
 import static me.devnatan.inventoryframework.runtime.thirdparty.InventoryUpdate.createTitleComponent;
 import static me.devnatan.inventoryframework.runtime.thirdparty.InventoryUpdate.getConstructor;
 import static me.devnatan.inventoryframework.runtime.thirdparty.InventoryUpdate.getContainerOrName;
@@ -11,12 +10,14 @@ import static me.devnatan.inventoryframework.runtime.thirdparty.InventoryUpdate.
 import static me.devnatan.inventoryframework.runtime.thirdparty.InventoryUpdate.setField;
 import static me.devnatan.inventoryframework.runtime.thirdparty.InventoryUpdate.setFieldHandle;
 import static me.devnatan.inventoryframework.runtime.thirdparty.InventoryUpdate.useContainers;
+import static me.devnatan.inventoryframework.runtime.thirdparty.ReflectionUtils.ENTITY_PLAYER;
 import static me.devnatan.inventoryframework.runtime.thirdparty.ReflectionUtils.getNMSClass;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.util.Objects;
 import me.devnatan.inventoryframework.runtime.thirdparty.InventoryUpdate;
+import me.devnatan.inventoryframework.runtime.thirdparty.McVersion;
 import me.devnatan.inventoryframework.runtime.thirdparty.ReflectionUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -114,7 +115,7 @@ class AnvilInputNMS {
             SET_PLAYER_ACTIVE_CONTAINER.invoke(entityPlayer, anvilContainer);
             CONTAINER_WINDOW_ID.invoke(anvilContainer, windowId);
 
-            if (ReflectionUtils.supports(19)) {
+            if (McVersion.supports(19)) {
                 INIT_MENU.invoke(entityPlayer, anvilContainer);
             } else {
                 ADD_CONTAINER_SLOT_LISTENER.invoke(anvilContainer, player);

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/runtime/thirdparty/McVersion.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/runtime/thirdparty/McVersion.java
@@ -6,9 +6,6 @@ import org.bukkit.Bukkit;
 public class McVersion implements Comparable<McVersion> {
 
     private static final McVersion CURRENT_VERSION;
-    private static final McVersion v1_17 = new McVersion(1, 17);
-    public static final McVersion v1_21_1 = new McVersion(1, 21, 1);
-    public static final McVersion v1_21_3 = new McVersion(1, 21, 3);
 
     static {
         final int currentMajor = Integer.parseInt(Bukkit.getBukkitVersion().split("\\.")[0]);
@@ -52,10 +49,6 @@ public class McVersion implements Comparable<McVersion> {
      */
     public static McVersion current() {
         return CURRENT_VERSION;
-    }
-
-    public boolean hasVersionInNmsPackageName() {
-        return !this.isAtLeast(v1_17);
     }
 
     public boolean isAtLeast(final McVersion other) {
@@ -124,5 +117,30 @@ public class McVersion implements Comparable<McVersion> {
 
     public boolean isAtLeast(final int major, final int minor) {
         return this.isAtLeast(new McVersion(major, minor));
+    }
+
+    /**
+     * Checks whether the server version is equal or greater than the given version.
+     *
+     * @param minorNumber the version to compare the server version with.
+     * @return true if the version is equal or newer, otherwise false.
+     * @see #CURRENT_VERSION
+     * @since 4.0.0
+     */
+    public static boolean supports(int minorNumber) {
+        return CURRENT_VERSION.isAtLeast(1, minorNumber);
+    }
+
+    /**
+     * Checks whether the server version is equal or greater than the given version.
+     *
+     * @param minorNumber the version to compare the server version with.
+     * @param patchNumber the version to compare the server version with.
+     * @return true if the version is equal or newer, otherwise false.
+     * @see #CURRENT_VERSION
+     * @since 4.0.0
+     */
+    public static boolean supports(int minorNumber, int patchNumber) {
+        return CURRENT_VERSION.isAtLeast(1, minorNumber, patchNumber);
     }
 }

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/pipeline/GlobalClickInterceptor.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/pipeline/GlobalClickInterceptor.kt
@@ -20,8 +20,7 @@ class GlobalClickInterceptor : PipelineInterceptor<VirtualView> {
 
         // inherit cancellation so we can un-cancel it
         subject.isCancelled =
-            event.isCancelled ||
-            subject.config.isOptionSet(ViewConfig.CANCEL_ON_CLICK, true)
+            (event.isCancelled || subject.config.isOptionSet(ViewConfig.CANCEL_ON_CLICK, true))
         subject.root.onClick(subject)
     }
 }


### PR DESCRIPTION
Well remove some code dublications for reflectstions.

Move over `supports` to `McVersion` to make it avalible when Reflections Utils fails.

Adds Support for 1.21.4 (Including Anvil-Input)

Fixes #699 
