### PR TITLE
chore: use new Maven Central publication mechanism

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
               uses: gradle/actions/setup-gradle@v4
 
             - name: Publish to Maven Central
-              run: ./gradlew publishToMavenCentral --stacktrace --no-configuration-cache
+              run: ./gradlew publishAndReleaseToMavenCentral --no-daemon --stacktrace --no-configuration-cache
               env:
                   USERNAME: ${{ github.actor }}
                   TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
                   settings-path: ${{ github.workspace }}
 
             - name: Set up Gradle
-              uses: actions/setup-java@v4
+              uses: gradle/actions/setup-gradle@v4
 
             - name: Publish to Maven Central
               run: ./gradlew publishToMavenCentral --stacktrace --no-configuration-cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,12 @@ on:
     types: [published]
   workflow_dispatch:
 
+env:
+  MAVEN_CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+  MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+  SIGNING_KEY: ${{ secrets.OSSRH_SIGNING_KEY }}
+  SIGNING_PASSWORD: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -12,26 +18,26 @@ jobs:
             contents: read
             packages: write
         steps:
-            - uses: actions/checkout@v3
-            - name: Set up JDK
-              uses: actions/setup-java@v3
+            - name: Checkout Application Repository
+              uses: actions/checkout@v4
+
+            - name: Set up JDK 21
+              uses: actions/setup-java@v4
               with:
                   java-version: '21'
                   distribution: 'temurin'
                   server-id: github
                   settings-path: ${{ github.workspace }}
-            - name: Build with Gradle
-              uses: gradle/gradle-build-action@cd3cedc781988c804f626f4cd2dc51d0bdf02a12
-              with:
-                  arguments: build -x check
-            - name: Publish
-              uses: gradle/gradle-build-action@cd3cedc781988c804f626f4cd2dc51d0bdf02a12
-              with:
-                  arguments: publish
+
+            - name: Set up Gradle
+              uses: actions/setup-java@v4
+
+            - name: Publish to Maven Central
+              run: ./gradlew publishToMavenCentral --stacktrace --no-configuration-cache
               env:
                   USERNAME: ${{ github.actor }}
                   TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-                  OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-                  OSSRH_SIGNING_KEY: ${{ secrets.OSSRH_SIGNING_KEY }}
-                  OSSRH_SIGNING_PASSWORD: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+                  MAVEN_CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+                  MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+                  SIGNING_KEY: ${{ secrets.OSSRH_SIGNING_KEY }}
+                  SIGNING_PASSWORD: ${{ secrets.OSSRH_SIGNING_PASSWORD }}

--- a/build-logic/conventions/build.gradle.kts
+++ b/build-logic/conventions/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("com.diffplug.spotless:spotless-plugin-gradle:7.0.2")
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:7.0.2")
 }
 
 gradlePlugin {

--- a/build-logic/conventions/build.gradle.kts
+++ b/build-logic/conventions/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `kotlin-dsl`
+    id("com.vanniktech.maven.publish.base") version "0.31.0" apply false
 }
 
 repositories {
@@ -8,6 +9,7 @@ repositories {
 
 dependencies {
     implementation("com.diffplug.spotless:spotless-plugin-gradle:7.0.2")
+    implementation("com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin:0.31.0")
 }
 
 gradlePlugin {

--- a/build-logic/conventions/src/main/kotlin/LibraryConventionPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/LibraryConventionPlugin.kt
@@ -9,7 +9,6 @@ import org.gradle.external.javadoc.JavadocMemberLevel
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.getByType
-import org.gradle.kotlin.dsl.kotlin
 import org.gradle.kotlin.dsl.withType
 
 class LibraryConventionPlugin : Plugin<Project> {
@@ -25,7 +24,8 @@ class LibraryConventionPlugin : Plugin<Project> {
         val extension = project.extensions.create<InventoryFrameworkExtension>("inventoryFramework")
         project.afterEvaluate {
             if (extension.publish.get()) {
-                configureMavenPublish()
+                plugins.apply("com.vanniktech.maven.publish.base")
+                configureInventoryFrameworkPublication()
             }
         }
     }

--- a/build-logic/conventions/src/main/kotlin/Publish.kt
+++ b/build-logic/conventions/src/main/kotlin/Publish.kt
@@ -53,9 +53,9 @@ fun Project.configureMavenPublish() {
                 name = "OSSRH"
                 url = uri(
                     if (isReleaseVersion)
-                        "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+                        "https://central.sonatype.com/repository/maven-snapshots/"
                     else
-                        "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+                        "https://ossrh-staging-api.central.sonatype.com/service/local/"
                 )
                 credentials {
                     username = findProperty("ossrh.username") as String? ?: System.getenv("OSSRH_USERNAME")

--- a/build-logic/conventions/src/main/kotlin/Publish.kt
+++ b/build-logic/conventions/src/main/kotlin/Publish.kt
@@ -8,7 +8,6 @@ fun Project.configureMavenPublish() {
     plugins.apply("maven-publish")
 
     val publicationVersion = project.version.toString() + "-SNAPSHOT"
-    val isReleaseVersion = !publicationVersion.endsWith("SNAPSHOT")
 
     configure<PublishingExtension> {
         publications {
@@ -49,15 +48,10 @@ fun Project.configureMavenPublish() {
         repositories {
             maven {
                 name = "OSSRH"
-                url = uri(
-                    if (isReleaseVersion)
-                        "https://ossrh-staging-api.central.sonatype.com/service/local/"
-                    else
-                        "https://central.sonatype.com/repository/maven-snapshots/"
-                )
+                url = uri("https://central.sonatype.com/api/v1/publisher/maven")
                 credentials {
                     username = findProperty("ossrh.username") as String? ?: System.getenv("OSSRH_USERNAME")
-                    password = findProperty("ossrh.password") as String? ?: System.getenv("OSSRH_PASSWORD")
+                    password = findProperty("ossrh.token") as String? ?: System.getenv("OSSRH_TOKEN")
                 }
             }
         }

--- a/build-logic/conventions/src/main/kotlin/Publish.kt
+++ b/build-logic/conventions/src/main/kotlin/Publish.kt
@@ -1,59 +1,13 @@
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.Project
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.create
 
-fun Project.configureMavenPublish() {
-    plugins.apply("maven-publish")
-
-    val publicationVersion = project.version.toString() + "-SNAPSHOT"
-
-    configure<PublishingExtension> {
-        publications {
-            create<MavenPublication>("javaOSSRH") {
-                groupId = rootProject.group.toString()
-                artifactId = project.name
-                version = publicationVersion
-                from(components.named("java").get())
-
-                pom {
-                    name.set("inventory-framework")
-                    description.set("Minecraft Inventory API framework")
-                    url.set("https://github.com/DevNatan/inventory-framework")
-                    inceptionYear.set("2020")
-
-                    licenses {
-                        license {
-                            name.set("MIT License")
-                            url.set("https://github.com/DevNatan/inventory-framework/blob/main/LICENSE")
-                        }
-                    }
-                    developers {
-                        developer {
-                            name.set("Natan Vieira do Nascimento")
-                            email.set("natanvnascimento@gmail.com")
-                            url.set("https://github.com/DevNatan")
-                        }
-                    }
-                    scm {
-                        connection.set("scm:git:git:github.com/DevNatan/inventoryframework.git")
-                        developerConnection.set("scm:git:https://github.com/DevNatan/inventoryframework.git")
-                        url.set("https://github.com/DevNatan/inventoryframework")
-                    }
-                }
-            }
-        }
-
-        repositories {
-            maven {
-                name = "OSSRH"
-                url = uri("https://central.sonatype.com/api/v1/publisher/maven")
-                credentials {
-                    username = findProperty("ossrh.username") as String? ?: System.getenv("OSSRH_USERNAME")
-                    password = findProperty("ossrh.token") as String? ?: System.getenv("OSSRH_TOKEN")
-                }
-            }
-        }
+fun Project.configureInventoryFrameworkPublication() {
+    extensions.configure<MavenPublishBaseExtension> {
+        publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+        signAllPublications()
+        pomFromGradleProperties()
+        configureBasedOnAppliedPlugins()
     }
 }

--- a/build-logic/conventions/src/main/kotlin/Publish.kt
+++ b/build-logic/conventions/src/main/kotlin/Publish.kt
@@ -3,12 +3,9 @@ import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.the
-import org.gradle.plugins.signing.SigningExtension
 
 fun Project.configureMavenPublish() {
     plugins.apply("maven-publish")
-    plugins.apply("signing")
 
     val publicationVersion = project.version.toString() + "-SNAPSHOT"
     val isReleaseVersion = !publicationVersion.endsWith("SNAPSHOT")
@@ -64,15 +61,5 @@ fun Project.configureMavenPublish() {
                 }
             }
         }
-    }
-
-    configure<SigningExtension> {
-        isRequired = isReleaseVersion && gradle.taskGraph.hasTask("publish")
-        useInMemoryPgpKeys(
-            findProperty("signing.keyId") as String? ?: System.getenv("OSSRH_SIGNING_KEY"),
-            findProperty("signing.password") as String? ?: System.getenv("OSSRH_SIGNING_PASSWORD")
-        )
-
-        sign(the<PublishingExtension>().publications.named("javaOSSRH").get())
     }
 }

--- a/build-logic/conventions/src/main/kotlin/Publish.kt
+++ b/build-logic/conventions/src/main/kotlin/Publish.kt
@@ -10,14 +10,15 @@ fun Project.configureMavenPublish() {
     plugins.apply("maven-publish")
     plugins.apply("signing")
 
-    val isReleaseVersion = !project.version.toString().endsWith("SNAPSHOT")
+    val publicationVersion = project.version.toString() + "-SNAPSHOT"
+    val isReleaseVersion = !publicationVersion.endsWith("SNAPSHOT")
 
     configure<PublishingExtension> {
         publications {
             create<MavenPublication>("javaOSSRH") {
                 groupId = rootProject.group.toString()
                 artifactId = project.name
-                version = rootProject.version.toString()
+                version = publicationVersion
                 from(components.named("java").get())
 
                 pom {

--- a/build-logic/conventions/src/main/kotlin/Publish.kt
+++ b/build-logic/conventions/src/main/kotlin/Publish.kt
@@ -53,9 +53,9 @@ fun Project.configureMavenPublish() {
                 name = "OSSRH"
                 url = uri(
                     if (isReleaseVersion)
-                        "https://central.sonatype.com/repository/maven-snapshots/"
-                    else
                         "https://ossrh-staging-api.central.sonatype.com/service/local/"
+                    else
+                        "https://central.sonatype.com/repository/maven-snapshots/"
                 )
                 credentials {
                     username = findProperty("ossrh.username") as String? ?: System.getenv("OSSRH_USERNAME")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.spotless) apply false
     alias(libs.plugins.kotlin) apply false
+    alias(libs.plugins.publish) apply false
 }
 
 group = "me.devnatan"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,4 @@ plugins {
 }
 
 group = "me.devnatan"
-version = "3.3.0"
+version = "3.3.0-SNAPSHOT"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,4 @@ plugins {
 }
 
 group = "me.devnatan"
-version = "3.3.0-SNAPSHOT"
+version = "3.3.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,23 @@
 org.gradle.parallel=true
-org.gradle.configureondemand=true
-org.gradle.configuration-cache=true
-org.gradle.configuration-cache.parallel=true
 kotlin.incremental=true
 kotlin.jvm.target=21
 kotlin.compiler.execution.strategy=daemon
+mavenCentralUsername=hF0LIjUb
+mavenCentralPassword=YyOxPjtftSzmgN8sYNuS0beTp7Z916E6tB3Fhg8ftgIm
+
+### Publication ###
+POM_NAME=inventory-framework
+POM_DESCRIPTION=Minecraft Inventory API framework
+POM_URL=https://github.com/DevNatan/inventory-framework
+POM_INCEPTION_YEAR=2020
+POM_SCM_URL=https://github.com/DevNatan/inventoryframework
+POM_SCM_CONNECTION=scm:git:git:github.com/DevNatan/inventoryframework.git
+POM_SCM_DEV_CONNECTION=scm:git:https://github.com/DevNatan/inventoryframework.git
+POM_LICENCE_NAME=MIT License
+POM_LICENSE_URL=https://github.com/DevNatan/inventory-framework/blob/main/LICENSE
+POM_DEVELOPER_ID=DevNatan
+POM_DEVELOPER_NAME=Natan Vieira do Nascimento
+POM_DEVELOPER_URL=natanvnascimento@gmail.com
+POM_DEVELOPER_EMAIL=https://github.com/DevNatan
+SONATYPE_HOST=CENTRAL_PORTAL
+RELEASE_SIGNING_ENABLED=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,3 +55,4 @@ spotless = { id = "com.diffplug.spotless", version.ref = "plugin-spotless" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 bukkit = { id = "de.eldoria.plugin-yml.bukkit", version.ref = "plugin-bukkit" }
 run-paper = { id = "xyz.jpenilla.run-paper", version =  "2.3.1" }
+publish = { id = "com.vanniktech.maven.publish.base", version = "0.31.0" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/inventory-framework-anvil-input/build.gradle.kts
+++ b/inventory-framework-anvil-input/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("me.devnatan.inventoryframework.library")
     alias(libs.plugins.kotlin)
+    id("me.devnatan.inventoryframework.library")
 }
 
 inventoryFramework {

--- a/inventory-framework-api/build.gradle.kts
+++ b/inventory-framework-api/build.gradle.kts
@@ -3,12 +3,12 @@ plugins {
     alias(libs.plugins.kotlin)
 }
 
-dependencies {
-    compileOnly(libs.adventure.api)
-}
-
 inventoryFramework {
     publish = true
+}
+
+dependencies {
+    compileOnly(libs.adventure.api)
 }
 
 kotlin {

--- a/inventory-framework-platform-bukkit/build.gradle.kts
+++ b/inventory-framework-platform-bukkit/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
+
 plugins {
     id("me.devnatan.inventoryframework.library")
     alias(libs.plugins.shadowjar)

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/runtime/InventoryFramework.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/runtime/InventoryFramework.java
@@ -4,5 +4,5 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public final class InventoryFramework extends JavaPlugin {
 
-    public static final String LIBRARY_VERSION = "3.3.0";
+    public static final String LIBRARY_VERSION = String.join(".", "3", "3", "0");
 }

--- a/inventory-framework-platform-minestom/build.gradle.kts
+++ b/inventory-framework-platform-minestom/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
     alias(libs.plugins.shadowjar)
 }
 
-inventoryFramework {
-    publish = true
-}
-
 dependencies {
     api(projects.inventoryFrameworkPlatform)
     compileOnly(libs.minestom)

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/pipeline/GlobalClickInterceptor.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/pipeline/GlobalClickInterceptor.kt
@@ -20,7 +20,8 @@ class GlobalClickInterceptor : PipelineInterceptor<VirtualView> {
 
         // inherit cancellation so we can un-cancel it
         subject.isCancelled =
-            event.isCancelled || subject.config.isOptionSet(ViewConfig.CANCEL_ON_CLICK, true)
+            event.isCancelled ||
+            subject.config.isOptionSet(ViewConfig.CANCEL_ON_CLICK, true)
         subject.root.onClick(subject)
     }
 }


### PR DESCRIPTION
OSSRH service will reach the end of life and dashboard is insanely buggy. This PR change release and snapshot publication urls to the new Maven Central publisher urls