### PR TITLE
feat: allow earlier state update

### DIFF
--- a/inventory-framework-anvil-input/src/main/java/me/devnatan/inventoryframework/AnvilInputFeature.java
+++ b/inventory-framework-anvil-input/src/main/java/me/devnatan/inventoryframework/AnvilInputFeature.java
@@ -117,7 +117,7 @@ public final class AnvilInputFeature implements Feature<AnvilInputConfig, Void, 
             final ItemStack ingredientItem = requireNonNull(clickedInventory.getItem(INGREDIENT_SLOT));
             final ItemMeta ingredientMeta = requireNonNull(ingredientItem.getItemMeta());
             ingredientMeta.setDisplayName(text);
-            context.updateState(anvilInput.internalId(), text);
+            context.updateState(anvilInput, text);
             ingredientItem.setItemMeta(ingredientMeta);
 
             if (config.closeOnSelect) {
@@ -189,7 +189,7 @@ public final class AnvilInputFeature implements Feature<AnvilInputConfig, Void, 
             if (item == null || item.getType() == Material.AIR) return;
 
             final String input = requireNonNull(item.getItemMeta()).getDisplayName();
-            context.updateState(anvilInput.internalId(), input);
+            context.updateState(anvilInput, input);
         });
     }
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/state/StateValueHost.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/state/StateValueHost.java
@@ -61,11 +61,11 @@ public interface StateValueHost {
      * <p><b><i>This is an internal inventory-framework API that should not be used from outside of
      * this library. No compatibility guarantees are provided.</i></b>
      *
-     * @param id    The state id.
+     * @param state The target state to update.
      * @param value The new state value.
      */
     @ApiStatus.Internal
-    void updateState(long id, Object value);
+    void updateState(State<?> state, Object value);
 
     @ApiStatus.Internal
     void watchState(long id, StateWatcher listener);

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/component/PaginationImpl.java
@@ -438,7 +438,7 @@ public class PaginationImpl extends AbstractStateValue implements Pagination, In
      */
     private void simulateStateUpdate() {
         debug("[Pagination] State update simulation triggered on %d", getState().internalId());
-        host.updateState(getState().internalId(), this);
+        host.updateState(getState(), this);
     }
 
     @Override

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/state/BaseMutableState.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/state/BaseMutableState.java
@@ -14,6 +14,6 @@ public class BaseMutableState<T> extends BaseState<T> implements MutableState<T>
 
     @Override
     public final void set(T value, @NotNull StateValueHost host) {
-        host.updateState(internalId(), value);
+        host.updateState(this, value);
     }
 }

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/state/DefaultStateValueHost.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/state/DefaultStateValueHost.java
@@ -60,13 +60,13 @@ public class DefaultStateValueHost implements StateValueHost {
     }
 
     @Override
-    public void updateState(long id, Object value) {
-        final StateValue stateValue = getUninitializedStateValue(id);
+    public void updateState(State<?> state, Object value) {
+        final StateValue stateValue = getInternalStateValue(state);
         final Object oldValue = stateValue.get();
         stateValue.set(value);
 
         final Object newValue = stateValue.get();
-        IFDebug.debug("State %s updated (oldValue = %s, newValue = %s)", id, oldValue, newValue);
+        IFDebug.debug("State %s updated (oldValue = %s, newValue = %s)", state.internalId(), oldValue, newValue);
         callListeners(stateValue, listener -> listener.stateValueSet(this, stateValue, oldValue, newValue));
     }
 

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/state/MutableGenericStateImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/state/MutableGenericStateImpl.java
@@ -16,6 +16,6 @@ public final class MutableGenericStateImpl<T> extends BaseState<T> implements Mu
 
     @Override
     public void set(T value, @NotNull StateValueHost host) {
-        host.updateState(internalId(), value);
+        host.updateState(this, value);
     }
 }

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/CloseContext.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/CloseContext.java
@@ -132,8 +132,8 @@ public class CloseContext extends PlatformConfinedContext implements IFCloseCont
     }
 
     @Override
-    public final void updateState(long id, Object value) {
-        getParent().updateState(id, value);
+    public final void updateState(State<?> state, Object value) {
+        getParent().updateState(state, value);
     }
 
     @Override

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/SlotContext.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/context/SlotContext.java
@@ -128,8 +128,8 @@ public abstract class SlotContext extends PlatformContext implements IFSlotConte
     }
 
     @Override
-    public final void updateState(long id, Object value) {
-        getParent().updateState(id, value);
+    public final void updateState(State<?> state, Object value) {
+        getParent().updateState(state, value);
     }
 
     @Override

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/context/CloseContext.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/context/CloseContext.kt
@@ -88,10 +88,10 @@ class CloseContext
         override fun getUninitializedStateValue(stateId: Long): StateValue = getParent().getUninitializedStateValue(stateId)
 
         override fun updateState(
-            id: Long,
+            state: State<*>,
             value: Any,
         ) {
-            getParent().updateState(id, value)
+            getParent().updateState(state, value)
         }
 
         override fun toString(): String =

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/context/SlotContext.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/context/SlotContext.kt
@@ -98,10 +98,10 @@ abstract class SlotContext
         }
 
         override fun updateState(
-            id: Long,
+            state: State<*>,
             value: Any,
         ) {
-            getParent().updateState(id, value)
+            getParent().updateState(state, value)
         }
 
         override fun watchState(

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/pipeline/GlobalClickInterceptor.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/pipeline/GlobalClickInterceptor.kt
@@ -20,8 +20,7 @@ class GlobalClickInterceptor : PipelineInterceptor<VirtualView> {
 
         // inherit cancellation so we can un-cancel it
         subject.isCancelled =
-            event.isCancelled ||
-            subject.config.isOptionSet(ViewConfig.CANCEL_ON_CLICK, true)
+            event.isCancelled || subject.config.isOptionSet(ViewConfig.CANCEL_ON_CLICK, true)
         subject.root.onClick(subject)
     }
 }


### PR DESCRIPTION
Allows state to be updated while another state is being initialized e.g.: a lazy/computed state on its first data load. Also allows state values to be set on shared context before "sending" it to the player.