### PR TITLE
fix: relocation and versioning issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish package
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
+  push:
+    tags: [ 'v*.*.*' ]
 
 env:
   MAVEN_CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -16,7 +15,6 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
-            packages: write
         steps:
             - name: Checkout Application Repository
               uses: actions/checkout@v4
@@ -33,7 +31,7 @@ jobs:
               uses: gradle/actions/setup-gradle@v4
 
             - name: Publish to Maven Central
-              run: ./gradlew publishAndReleaseToMavenCentral --no-daemon --stacktrace --no-configuration-cache
+              run: ./gradlew publishAndReleaseToMavenCentral -Pversion=${{ github.ref_name }} --no-daemon --stacktrace --no-configuration-cache
               env:
                   USERNAME: ${{ github.actor }}
                   TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build-logic/conventions/src/main/kotlin/Extension.kt
+++ b/build-logic/conventions/src/main/kotlin/Extension.kt
@@ -6,4 +6,6 @@ import javax.inject.Inject
 abstract class InventoryFrameworkExtension @Inject constructor(objects: ObjectFactory) {
 
     val publish: Property<Boolean> = objects.property<Boolean>().convention(false)
+
+    val generateVersionFile: Property<Boolean> = objects.property<Boolean>().convention(false)
 }

--- a/build-logic/conventions/src/main/kotlin/GenerateVersionFileTask.kt
+++ b/build-logic/conventions/src/main/kotlin/GenerateVersionFileTask.kt
@@ -1,0 +1,61 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.register
+import java.io.File
+
+internal abstract class GenerateVersionFileTask : DefaultTask() {
+
+    init {
+        group = "inventoryFramework"
+    }
+
+    @get:Input
+    abstract val version: Property<String>
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @TaskAction
+    fun generate() {
+        val packageDir = outputDir.get().dir("me/devnatan/inventoryframework/runtime").asFile
+        packageDir.mkdirs()
+
+        val file = File(packageDir, "InventoryFramework.java")
+        file.writeText(
+            """
+            package me.devnatan.inventoryframework.runtime;
+
+            import org.bukkit.plugin.java.JavaPlugin;
+
+            public final class InventoryFramework extends JavaPlugin {
+
+                public static final String LIBRARY_VERSION = "${version.get()}";
+            }
+            
+            """.trimIndent()
+        )
+    }
+}
+
+internal fun Project.registerGenerateVersionFileTask() {
+    val generateVersionFileTask = tasks.register<GenerateVersionFileTask>("generateVersionFile") {
+        version.set(project.version.toString())
+        outputDir.set(layout.buildDirectory.dir("generated/sources/ifversion"))
+    }
+
+    extensions.configure<SourceSetContainer>("sourceSets") {
+        named("main") {
+            java.srcDir(generateVersionFileTask.flatMap { it.outputDir })
+        }
+    }
+
+    tasks.named("compileJava") {
+        dependsOn(generateVersionFileTask)
+    }
+}

--- a/build-logic/conventions/src/main/kotlin/LibraryConventionPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/LibraryConventionPlugin.kt
@@ -11,7 +11,7 @@ import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
 
-class LibraryConventionPlugin : Plugin<Project> {
+internal class LibraryConventionPlugin : Plugin<Project> {
 
     override fun apply(target: Project) = with(target) {
         group = rootProject.group
@@ -23,8 +23,10 @@ class LibraryConventionPlugin : Plugin<Project> {
 
         val extension = project.extensions.create<InventoryFrameworkExtension>("inventoryFramework")
         project.afterEvaluate {
+            if (extension.generateVersionFile.get())
+                registerGenerateVersionFileTask()
+
             if (extension.publish.get()) {
-                plugins.apply("com.vanniktech.maven.publish.base")
                 configureInventoryFrameworkPublication()
             }
         }
@@ -50,6 +52,7 @@ class LibraryConventionPlugin : Plugin<Project> {
             java {
                 removeUnusedImports()
                 palantirJavaFormat()
+                targetExclude("build/generated/sources/ifversion/**/*.java")
             }
             kotlin {
                 ktfmt().kotlinlangStyle()

--- a/build-logic/conventions/src/main/kotlin/Publish.kt
+++ b/build-logic/conventions/src/main/kotlin/Publish.kt
@@ -3,7 +3,9 @@ import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 
-fun Project.configureInventoryFrameworkPublication() {
+internal fun Project.configureInventoryFrameworkPublication() {
+    plugins.apply("com.vanniktech.maven.publish.base")
+
     extensions.configure<MavenPublishBaseExtension> {
         publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
         signAllPublications()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,20 @@ plugins {
 }
 
 group = "me.devnatan"
-version = "3.3.0"
+version = property("version")
+    .toString()
+    .takeUnless { it == "unspecified" }
+    ?.filterNot { it == 'v' } ?: nextGitTag()
+
+@Suppress("UnstableApiUsage")
+fun Project.nextGitTag(): String {
+    val latestTag = providers.exec {
+        commandLine("git", "describe", "--tags", "--abbrev=0")
+    }.standardOutput.asText.get().trim()
+
+    val versionParts = latestTag.removePrefix("v").split(".")
+    val major = versionParts.getOrNull(0)?.toIntOrNull() ?: 0
+    val minor = versionParts.getOrNull(1)?.toIntOrNull() ?: 0
+
+    return "$major.${minor + 1}.0-SNAPSHOT"
+}

--- a/inventory-framework-platform-bukkit/build.gradle.kts
+++ b/inventory-framework-platform-bukkit/build.gradle.kts
@@ -1,6 +1,3 @@
-import com.vanniktech.maven.publish.JavaLibrary
-import com.vanniktech.maven.publish.JavadocJar
-
 plugins {
     id("me.devnatan.inventoryframework.library")
     alias(libs.plugins.shadowjar)
@@ -9,6 +6,7 @@ plugins {
 
 inventoryFramework {
     publish = true
+    generateVersionFile = true
 }
 
 dependencies {

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/ViewFrame.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/ViewFrame.java
@@ -13,6 +13,7 @@ import me.devnatan.inventoryframework.feature.Feature;
 import me.devnatan.inventoryframework.feature.FeatureInstaller;
 import me.devnatan.inventoryframework.internal.BukkitElementFactory;
 import me.devnatan.inventoryframework.internal.PlatformUtils;
+import me.devnatan.inventoryframework.runtime.InventoryFramework;
 import me.devnatan.inventoryframework.runtime.thirdparty.Metrics;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -25,7 +26,7 @@ public class ViewFrame extends IFViewFrame<ViewFrame, View> {
 
     private static final String BSTATS_SYSTEM_PROP = "inventory-framework.enable-bstats";
     private static final int BSTATS_PROJECT_ID = 15518;
-    private static final String PLUGIN_FQN = "me.devnatan.inventoryframework.runtime.InventoryFramework";
+    private static final String PLUGIN_FQN = InventoryFramework.class.getName();
 
     private static final String RELOCATION_MESSAGE =
             "Inventory Framework is running as a shaded non-relocated library. It's extremely recommended that "

--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/runtime/InventoryFramework.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/runtime/InventoryFramework.java
@@ -1,8 +1,0 @@
-package me.devnatan.inventoryframework.runtime;
-
-import org.bukkit.plugin.java.JavaPlugin;
-
-public final class InventoryFramework extends JavaPlugin {
-
-    public static final String LIBRARY_VERSION = String.join(".", "3", "3", "0");
-}

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/ViewFrame.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/ViewFrame.kt
@@ -270,15 +270,6 @@ class ViewFrame private constructor(
 
     companion object {
         private const val BSTATS_SYSTEM_PROP = "inventory-framework.enable-bstats"
-        private const val BSTATS_PROJECT_ID = 15518
-        private const val PLUGIN_FQN = "me.devnatan.inventoryframework.runtime.InventoryFramework"
-
-        private const val RELOCATION_MESSAGE =
-            (
-                "Inventory Framework is running as a shaded non-relocated library. It's extremely recommended that " +
-                    "you relocate the library package. Learn more about on docs: " +
-                    "https://github.com/DevNatan/inventory-framework/wiki/Installation#preventing-library-conflicts"
-            )
 
         init {
             PlatformUtils.setFactory(MinestomElementFactory())

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/pipeline/GlobalClickInterceptor.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/pipeline/GlobalClickInterceptor.kt
@@ -20,8 +20,7 @@ class GlobalClickInterceptor : PipelineInterceptor<VirtualView> {
 
         // inherit cancellation so we can un-cancel it
         subject.isCancelled =
-            event.isCancelled ||
-            subject.config.isOptionSet(ViewConfig.CANCEL_ON_CLICK, true)
+            event.isCancelled || subject.config.isOptionSet(ViewConfig.CANCEL_ON_CLICK, true)
         subject.root.onClick(subject)
     }
 }


### PR DESCRIPTION
* Now plugin version on current build is based on the next release tag
* Due to this ^, version file is now auto-generated
* Fixed "inventory framework is shaded" message when using relocate

To create a .jar with a custom version is needed to pass use `version` property
```
./gradlew -Pversion=1.99.0 shadowJar
```