### PR TITLE
fix: broken view while transitioning from non-IF inventories

### DIFF
--- a/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/IFInventoryListener.java
+++ b/inventory-framework-platform-bukkit/src/main/java/me/devnatan/inventoryframework/IFInventoryListener.java
@@ -62,6 +62,8 @@ final class IFInventoryListener implements Listener {
     public void onInventoryClose(final InventoryCloseEvent event) {
         if (!(event.getPlayer() instanceof Player)) return;
 
+        if (!(event.getInventory().getHolder() instanceof IFRenderContext)) return;
+
         final Player player = (Player) event.getPlayer();
         final Viewer viewer = viewFrame.getViewer(player);
         if (viewer == null) return;


### PR DESCRIPTION
Since we removed early close to prevent flickering, now InventoryCloseEvent is being called after InventoryOpenEvent is called to the next inventory, this behavior causes a bug when transitioning from a non-InventoryFramework to a InventoryFramework view.