### PR TITLE
fix: IncompatibleClassChangeError on Dynamic Title Update pre MC 1.20.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 jetbrains-annotations = "26.0.2"
 # Do not update Spigot/Paper to 1.21, InventoryView changed from class to interface type
-# Dynamic Title Update feature will throw a a IncompatibleClassChangeError due to that change
+# Dynamic Title Update feature throws IncompatibleClassChangeError due to that
 # Feel free to implement a workaround on InventoryUpdate.java if u need to use a 1.21+ specific API
 spigot = "1.20.6-R0.1-SNAPSHOT"
 paperSpigot = "1.20.6-R0.1-SNAPSHOT"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,10 @@
 [versions]
 jetbrains-annotations = "26.0.2"
-spigot = "1.21.5-R0.1-SNAPSHOT"
-paperSpigot = "1.21.5-R0.1-SNAPSHOT"
+# Do not update Spigot/Paper to 1.21, InventoryView changed from class to interface type
+# Dynamic Title Update feature will throw a a IncompatibleClassChangeError due to that change
+# Feel free to implement a workaround on InventoryUpdate.java if u need to use a 1.21+ specific API
+spigot = "1.20.6-R0.1-SNAPSHOT"
+paperSpigot = "1.20.6-R0.1-SNAPSHOT"
 junit = "5.12.2"
 mockito = "4.11.0"
 adventure-api = "4.19.0"


### PR DESCRIPTION
In MC 1.21 org.bukkit.inventory.InventoryView became a `interface` (previously a `class`) so Dynamic Title Update that interacts with it directly throws a IncompatibleClassChangeError on pre MC 1.21 servers.

The workaround for that is using MC 1.20.6 dependency as we do not use any MC 1.21 specific API yet.

How to reproduce: try to use `context.updateTitle` using latest Inventory Framework version in a server that is not MC 1.21.

Stack trace:
```
[18:45:19 WARN]: java.lang.IncompatibleClassChangeError: Found class org.bukkit.inventory.InventoryView, but interface was expected
[18:45:19 WARN]:        at me.devnatan.inventoryframework.runtime.thirdparty.InventoryUpdate.updateInventory(InventoryUpdate.java:146)
[18:45:19 WARN]:        at me.devnatan.inventoryframework.BukkitViewContainer.changeTitle(BukkitViewContainer.java:148)
[18:45:19 WARN]:        at me.devnatan.inventoryframework.BukkitViewContainer.changeTitle(BukkitViewContainer.java:144)
```