### PR TITLE
update minestom to 1.21.5

### DIFF
--- a/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/view/SimplePagination.kt
+++ b/examples/minestom/src/main/kotlin/me/devnatan/inventoryframework/runtime/view/SimplePagination.kt
@@ -2,7 +2,7 @@ package me.devnatan.inventoryframework.runtime.view
 
 import me.devnatan.inventoryframework.View
 import me.devnatan.inventoryframework.ViewConfigBuilder
-import me.devnatan.inventoryframework.component.MinestomIemComponentBuilder
+import me.devnatan.inventoryframework.component.MinestomItemComponentBuilder
 import me.devnatan.inventoryframework.component.Pagination
 import me.devnatan.inventoryframework.context.Context
 import me.devnatan.inventoryframework.context.RenderContext
@@ -17,7 +17,7 @@ class SimplePagination : View() {
     private val state: State<Pagination> =
         lazyPaginationState(
             { _ -> getRandomItems(123).toMutableList() },
-            { _: Context, builder: MinestomIemComponentBuilder, index: Int, value: ItemStack ->
+            { _: Context, builder: MinestomItemComponentBuilder, index: Int, value: ItemStack ->
                 builder.withItem(value)
                 builder.onClick { ctx: SlotClickContext ->
                     ctx.player.sendMessage("You clicked on item $index")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ kotlin = "2.1.0"
 plugin-shadowjar = "8.3.6"
 plugin-spotless = "7.0.4"
 plugin-bukkit = "0.7.1"
-minestom = "87f6524aeb"
+minestom = "1_21_5-69b9a5d844"
 
 [libraries.spigot]
 module = "org.spigotmc:spigot-api"

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/IFInventoryListener.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/IFInventoryListener.kt
@@ -13,7 +13,7 @@ import net.minestom.server.event.inventory.InventoryPreClickEvent
 import net.minestom.server.event.item.PickupItemEvent
 import net.minestom.server.event.trait.EntityEvent
 import net.minestom.server.inventory.PlayerInventory
-import net.minestom.server.inventory.click.ClickType
+import net.minestom.server.inventory.click.Click
 import kotlin.jvm.optionals.getOrNull
 
 internal class IFInventoryListener(
@@ -38,17 +38,14 @@ internal class IFInventoryListener(
         val player = event.player
         val viewer = viewFrame.getViewer(player) ?: return
 
-        if (event.clickType == ClickType.DROP) {
+        if (event.click is Click.DropSlot) {
             val context: IFContext = viewer.activeContext
             if (!context.config.isOptionSet(ViewConfig.CANCEL_ON_DROP)) return
 
             event.isCancelled = context.config.getOptionValue(ViewConfig.CANCEL_ON_DROP)
             return
         }
-        if (
-            event.clickType == ClickType.LEFT_DRAGGING ||
-            event.clickType == ClickType.RIGHT_DRAGGING
-        ) {
+        if (event.click is Click.LeftDrag || event.click is Click.RightDrag) {
             val context: IFContext = viewer.activeContext
             if (!context.config.isOptionSet(ViewConfig.CANCEL_ON_DRAG)) return
 

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/View.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/View.kt
@@ -1,6 +1,6 @@
 package me.devnatan.inventoryframework
 
-import me.devnatan.inventoryframework.component.MinestomIemComponentBuilder
+import me.devnatan.inventoryframework.component.MinestomItemComponentBuilder
 import me.devnatan.inventoryframework.context.CloseContext
 import me.devnatan.inventoryframework.context.Context
 import me.devnatan.inventoryframework.context.OpenContext
@@ -22,7 +22,7 @@ open class View :
     PlatformView<
         ViewFrame,
         Player,
-        MinestomIemComponentBuilder,
+        MinestomItemComponentBuilder,
         Context,
         OpenContext,
         CloseContext,

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/component/MinestomItemComponentBuilder.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/component/MinestomItemComponentBuilder.kt
@@ -18,7 +18,7 @@ import java.util.function.Consumer
 import java.util.function.Predicate
 import java.util.function.Supplier
 
-class MinestomIemComponentBuilder
+class MinestomItemComponentBuilder
     private constructor(
         private val root: VirtualView,
         slot: Int,
@@ -34,7 +34,7 @@ class MinestomIemComponentBuilder
         watchingStates: Set<State<*>>,
         isManagedExternally: Boolean,
         displayCondition: Predicate<Context>?,
-    ) : DefaultComponentBuilder<MinestomIemComponentBuilder, Context>(
+    ) : DefaultComponentBuilder<MinestomItemComponentBuilder, Context>(
             reference,
             data,
             cancelOnClick,
@@ -44,7 +44,7 @@ class MinestomIemComponentBuilder
             isManagedExternally,
             displayCondition,
         ),
-        ItemComponentBuilder<MinestomIemComponentBuilder, Context>,
+        ItemComponentBuilder<MinestomItemComponentBuilder, Context>,
         ComponentFactory {
         private var slot: Int
         private var item: ItemStack?
@@ -81,7 +81,7 @@ class MinestomIemComponentBuilder
 
         override fun toString(): String =
             (
-                "BukkitItemComponentBuilder{" +
+                "MinestomItemComponentBuilder{" +
                     "slot=" +
                     slot +
                     ", item=" +
@@ -99,7 +99,7 @@ class MinestomIemComponentBuilder
         override fun isContainedWithin(position: Int): Boolean = position == slot
 
         /** {@inheritDoc} */
-        override fun withSlot(slot: Int): MinestomIemComponentBuilder {
+        override fun withSlot(slot: Int): MinestomItemComponentBuilder {
             this.slot = slot
             return this
         }
@@ -107,7 +107,7 @@ class MinestomIemComponentBuilder
         override fun withSlot(
             row: Int,
             column: Int,
-        ): MinestomIemComponentBuilder {
+        ): MinestomItemComponentBuilder {
             val container: ViewContainer = (root as IFRenderContext).getContainer()
             return withSlot(
                 SlotConverter.convertSlot(
@@ -126,7 +126,7 @@ class MinestomIemComponentBuilder
          * @param item The new fallback item stack.
          * @return This item builder.
          */
-        fun withItem(item: ItemStack?): MinestomIemComponentBuilder {
+        fun withItem(item: ItemStack?): MinestomItemComponentBuilder {
             this.item = item
             return this
         }
@@ -140,7 +140,7 @@ class MinestomIemComponentBuilder
          * @return This item builder.
          */
         @Suppress("UNCHECKED_CAST")
-        fun onRender(renderHandler: Consumer<in SlotRenderContext>?): MinestomIemComponentBuilder {
+        fun onRender(renderHandler: Consumer<in SlotRenderContext>?): MinestomItemComponentBuilder {
             this.renderHandler = renderHandler as? Consumer<in IFSlotRenderContext>
             return this
         }
@@ -153,7 +153,7 @@ class MinestomIemComponentBuilder
          * @param renderFactory The render handler.
          * @return This item builder.
          */
-        fun renderWith(renderFactory: Supplier<ItemStack>): MinestomIemComponentBuilder =
+        fun renderWith(renderFactory: Supplier<ItemStack>): MinestomItemComponentBuilder =
             onRender { render: SlotRenderContext ->
                 render.item = renderFactory.get()
             }
@@ -168,7 +168,7 @@ class MinestomIemComponentBuilder
          * @return This item builder.
          */
         @Suppress("UNCHECKED_CAST")
-        fun onClick(clickHandler: Consumer<in SlotClickContext>?): MinestomIemComponentBuilder {
+        fun onClick(clickHandler: Consumer<in SlotClickContext>?): MinestomItemComponentBuilder {
             this.clickHandler = clickHandler as? Consumer<in IFSlotClickContext>
             return this
         }
@@ -182,7 +182,7 @@ class MinestomIemComponentBuilder
          * @param clickHandler The click handler.
          * @return This item builder.
          */
-        fun onClick(clickHandler: Runnable?): MinestomIemComponentBuilder =
+        fun onClick(clickHandler: Runnable?): MinestomItemComponentBuilder =
             onClick(
                 if (clickHandler == null) {
                     null
@@ -198,7 +198,7 @@ class MinestomIemComponentBuilder
          * @return This item builder.
          */
         @Suppress("UNCHECKED_CAST")
-        fun onUpdate(updateHandler: Consumer<SlotContext>?): MinestomIemComponentBuilder {
+        fun onUpdate(updateHandler: Consumer<SlotContext>?): MinestomItemComponentBuilder {
             this.updateHandler = updateHandler as? Consumer<in IFSlotContext>
             return this
         }
@@ -221,8 +221,8 @@ class MinestomIemComponentBuilder
                 reference,
             )
 
-        override fun copy(): MinestomIemComponentBuilder =
-            MinestomIemComponentBuilder(
+        override fun copy(): MinestomItemComponentBuilder =
+            MinestomItemComponentBuilder(
                 root,
                 slot,
                 item,

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/context/RenderContext.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/context/RenderContext.kt
@@ -6,7 +6,7 @@ import me.devnatan.inventoryframework.View
 import me.devnatan.inventoryframework.ViewConfig
 import me.devnatan.inventoryframework.ViewContainer
 import me.devnatan.inventoryframework.Viewer
-import me.devnatan.inventoryframework.component.MinestomIemComponentBuilder
+import me.devnatan.inventoryframework.component.MinestomItemComponentBuilder
 import net.kyori.adventure.text.Component
 import net.minestom.server.entity.Player
 import net.minestom.server.item.ItemStack
@@ -24,7 +24,7 @@ class RenderContext
         viewers: Map<String, Viewer>,
         subject: Viewer,
         initialData: Any?,
-    ) : PlatformRenderContext<MinestomIemComponentBuilder, Context>(
+    ) : PlatformRenderContext<MinestomItemComponentBuilder, Context>(
             id,
             root,
             config,
@@ -65,7 +65,7 @@ class RenderContext
         fun slot(
             slot: Int,
             item: ItemStack,
-        ): MinestomIemComponentBuilder = slot(slot).withItem(item)
+        ): MinestomItemComponentBuilder = slot(slot).withItem(item)
 
         /**
          * Adds an item at the specific column and ROW (X, Y) in that context's container.
@@ -78,7 +78,7 @@ class RenderContext
             row: Int,
             column: Int,
             item: ItemStack?,
-        ): MinestomIemComponentBuilder = slot(row, column).withItem(item)
+        ): MinestomItemComponentBuilder = slot(row, column).withItem(item)
 
         /**
          * Sets an item in the first slot of this context's container.
@@ -86,7 +86,7 @@ class RenderContext
          * @param item The item that'll be set.
          * @return An item builder to configure the item.
          */
-        fun firstSlot(item: ItemStack?): MinestomIemComponentBuilder = firstSlot().withItem(item)
+        fun firstSlot(item: ItemStack?): MinestomItemComponentBuilder = firstSlot().withItem(item)
 
         /**
          * Sets an item in the last slot of this context's container.
@@ -94,7 +94,7 @@ class RenderContext
          * @param item The item that'll be set.
          * @return An item builder to configure the item.
          */
-        fun lastSlot(item: ItemStack?): MinestomIemComponentBuilder = lastSlot().withItem(item)
+        fun lastSlot(item: ItemStack?): MinestomItemComponentBuilder = lastSlot().withItem(item)
 
         /**
          * Adds an item in the next available slot of this context's container.
@@ -102,7 +102,7 @@ class RenderContext
          * @param item The item that'll be added.
          * @return An item builder to configure the item.
          */
-        fun availableSlot(item: ItemStack?): MinestomIemComponentBuilder = availableSlot().withItem(item)
+        fun availableSlot(item: ItemStack?): MinestomItemComponentBuilder = availableSlot().withItem(item)
 
         /**
          * Defines the item that will represent a character provided in the context layout.
@@ -114,16 +114,16 @@ class RenderContext
         fun layoutSlot(
             character: Char,
             item: ItemStack?,
-        ): MinestomIemComponentBuilder = layoutSlot(character).withItem(item)
+        ): MinestomItemComponentBuilder = layoutSlot(character).withItem(item)
 
         /**
          * *** This API is experimental and is not subject to the general compatibility guarantees such
          * API may be changed or may be removed completely in any further release. ***
          */
         @ApiStatus.Experimental
-        fun resultSlot(item: ItemStack?): MinestomIemComponentBuilder = resultSlot().withItem(item)
+        fun resultSlot(item: ItemStack?): MinestomItemComponentBuilder = resultSlot().withItem(item)
 
-        override fun createBuilder(): MinestomIemComponentBuilder = MinestomIemComponentBuilder(this)
+        override fun createBuilder(): MinestomItemComponentBuilder = MinestomItemComponentBuilder(this)
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/context/SlotClickContext.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/context/SlotClickContext.kt
@@ -7,7 +7,7 @@ import me.devnatan.inventoryframework.component.Component
 import net.minestom.server.entity.Player
 import net.minestom.server.event.inventory.InventoryPreClickEvent
 import net.minestom.server.inventory.PlayerInventory
-import net.minestom.server.inventory.click.ClickType
+import net.minestom.server.inventory.click.Click
 import net.minestom.server.item.ItemStack
 import org.jetbrains.annotations.ApiStatus
 
@@ -31,7 +31,7 @@ class SlotClickContext
 
         override val item: ItemStack
             /** The item that was clicked. */
-            get() = clickOrigin.cursorItem
+            get() = clickOrigin.clickedItem
 
         override fun getComponent(): Component? = clickedComponent
 
@@ -48,22 +48,24 @@ class SlotClickContext
 
         override fun getClickedSlot(): Int = clickOrigin.slot
 
-        override fun isLeftClick(): Boolean = clickOrigin.clickType == ClickType.LEFT_CLICK
+        override fun isLeftClick(): Boolean = clickOrigin.click is Click.Left
 
-        override fun isRightClick(): Boolean = clickOrigin.clickType == ClickType.RIGHT_CLICK
+        override fun isRightClick(): Boolean = clickOrigin.click is Click.Right
 
         override fun isMiddleClick(): Boolean = false
 
         override fun isShiftClick(): Boolean {
-            val clickType = clickOrigin.clickType
-            return clickType == ClickType.SHIFT_CLICK
+            val clickType = clickOrigin.click
+            return clickType is Click.LeftShift || clickType is Click.RightShift
         }
 
-        override fun isKeyboardClick(): Boolean = clickOrigin.clickType == ClickType.CHANGE_HELD
+        override fun isKeyboardClick(): Boolean = clickOrigin.click is Click.HotbarSwap
 
         override fun isOutsideClick(): Boolean = clickOrigin.slot < 0
 
-        override fun getClickIdentifier(): String = clickOrigin.clickType.name
+        override fun getClickIdentifier(): String =
+            clickOrigin.click.javaClass.simpleName
+                .lowercase()
 
         override fun isOnEntityContainer(): Boolean = clickOrigin.inventory is PlayerInventory
 

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/internal/MinestomElementFactory.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/internal/MinestomElementFactory.kt
@@ -11,7 +11,7 @@ import me.devnatan.inventoryframework.Viewer
 import me.devnatan.inventoryframework.VirtualView
 import me.devnatan.inventoryframework.component.Component
 import me.devnatan.inventoryframework.component.ComponentBuilder
-import me.devnatan.inventoryframework.component.MinestomIemComponentBuilder
+import me.devnatan.inventoryframework.component.MinestomItemComponentBuilder
 import me.devnatan.inventoryframework.context.CloseContext
 import me.devnatan.inventoryframework.context.Context
 import me.devnatan.inventoryframework.context.IFCloseContext
@@ -166,7 +166,7 @@ class MinestomElementFactory : ElementFactory() {
         parent: IFRenderContext,
     ): IFCloseContext = CloseContext(viewer, parent)
 
-    override fun createComponentBuilder(root: VirtualView): ComponentBuilder<*, Context> = MinestomIemComponentBuilder(root)
+    override fun createComponentBuilder(root: VirtualView): ComponentBuilder<*, Context> = MinestomItemComponentBuilder(root)
 
     override fun worksInCurrentPlatform(): Boolean = true
 

--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/pipeline/GlobalClickInterceptor.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/pipeline/GlobalClickInterceptor.kt
@@ -20,7 +20,8 @@ class GlobalClickInterceptor : PipelineInterceptor<VirtualView> {
 
         // inherit cancellation so we can un-cancel it
         subject.isCancelled =
-            event.isCancelled || subject.config.isOptionSet(ViewConfig.CANCEL_ON_CLICK, true)
+            event.isCancelled ||
+            subject.config.isOptionSet(ViewConfig.CANCEL_ON_CLICK, true)
         subject.root.onClick(subject)
     }
 }


### PR DESCRIPTION
Minestom 1.21.5 received an inventory rework, primarily with the click's being moved to a sealed interface instead of enums.