### PR TITLE
Update open methods to return nullable String

### DIFF
--- a/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/ViewFrame.kt
+++ b/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/ViewFrame.kt
@@ -30,7 +30,7 @@ class ViewFrame private constructor(
     fun open(
         viewClass: Class<out View>,
         player: Player,
-    ): String = open(viewClass, player, null)
+    ): String? = open(viewClass, player, null)
 
     /**
      * Opens a view to a player with initial data.
@@ -44,7 +44,7 @@ class ViewFrame private constructor(
         viewClass: Class<out View>,
         player: Player,
         initialData: Any?,
-    ): String = open(viewClass, listOf(player), initialData)
+    ): String? = open(viewClass, listOf(player), initialData)
 
     /**
      * Opens a view to more than one player.
@@ -62,7 +62,7 @@ class ViewFrame private constructor(
     fun open(
         viewClass: Class<out View>,
         players: Collection<Player>,
-    ): String = open(viewClass, players, null)
+    ): String? = open(viewClass, players, null)
 
     /**
      * Opens a view to more than one player with initial data.
@@ -82,7 +82,7 @@ class ViewFrame private constructor(
         viewClass: Class<out View>,
         players: Collection<Player>,
         initialData: Any?,
-    ): String = internalOpen(viewClass, players.associateBy { it.uuid.toString() }, initialData)
+    ): String? = internalOpen(viewClass, players.associateBy { it.uuid.toString() }, initialData)
 
     /**
      * Opens an already active context to a player.


### PR DESCRIPTION
This PR fixes the following issue sometimes occurring on Minestom servers:
```
java.lang.NullPointerException: internalOpen(...) must not be null at
me.devnatan.inventoryframework.ViewFrame.open(ViewFrame.kt:85) at
me.devnatan.inventoryframework.ViewFrame.open(ViewFrame.kt:47) at
me.devnatan.inventoryframework.ViewFrame.open(ViewFrame.kt:33)
```

This happens because in [ViewFrame.java#L160](https://github.com/DevNatan/inventory-framework/blob/main/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/IFViewFrame.java#L160C9-L160C53) the `internalOpen` method can possibly return `null`, but the `open` method in [ViewFrame.kt#L85](https://github.com/DevNatan/inventory-framework/blob/main/inventory-framework-platform-minestom/src/main/kotlin/me/devnatan/inventoryframework/ViewFrame.kt#L85C6-L85C16) wants to always return a String and not `null`.

---

Closes #767 