### PR TITLE
Fix per-player configuration

### DIFF
--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/ViewConfig.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/ViewConfig.java
@@ -154,8 +154,8 @@ public class ViewConfig {
     }
 
     private <T> T merge(ViewConfig other, Function<ViewConfig, T> retriever, Function<T, Boolean> mergeCondition) {
-        T value = retriever.apply(other);
-        if (!mergeCondition.apply(value)) return retriever.apply(this);
+        T value = retriever.apply(this);
+        if (!mergeCondition.apply(value)) return retriever.apply(other);
         return value;
     }
 


### PR DESCRIPTION
To reproduce:
1. Set inventory title to "A" on `onInit`
2. Set inventory title to "B" on `onOpen`

Inventory title must be "B" once open.