### PR TITLE
Update bug report template with new platforms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,7 +38,8 @@ body:
       description: On which platform did the bug occur?
       options:
         - label: Bukkit
-        - label: Sponge
+        - label: Paper
+        - label: Minestom
         - label: Other
   - type: input
     id: server-version


### PR DESCRIPTION
Added new platform options 'Paper' and 'Minestom' to the bug report template.