### PR TITLE
feat: implement Timer state

### DIFF
--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/SamplePlugin.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/SamplePlugin.java
@@ -22,7 +22,8 @@ public class SamplePlugin extends JavaPlugin {
                         new Failing(),
                         new SimplePagination(),
                         new AutoUpdate(),
-                        new PaginationOrientation())
+                        new PaginationOrientation(),
+                        new TimerSample())
                 .register();
 
         IFExampleCommandExecutor command = new IFExampleCommandExecutor(viewFrame);

--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/commands/IFExampleCommandExecutor.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/commands/IFExampleCommandExecutor.java
@@ -11,6 +11,7 @@ import me.devnatan.inventoryframework.runtime.view.AutoUpdate;
 import me.devnatan.inventoryframework.runtime.view.Failing;
 import me.devnatan.inventoryframework.runtime.view.PaginationOrientation;
 import me.devnatan.inventoryframework.runtime.view.SimplePagination;
+import me.devnatan.inventoryframework.runtime.view.TimerSample;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -30,6 +31,7 @@ public class IFExampleCommandExecutor implements CommandExecutor, TabCompleter {
         views.put("simple-pagination", SimplePagination.class);
         views.put("auto-update", AutoUpdate.class);
         views.put("pagination", PaginationOrientation.class);
+        views.put("timer", TimerSample.class);
     }
 
     private final ViewFrame viewFrame;

--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/TimerSample.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/TimerSample.java
@@ -1,0 +1,82 @@
+package me.devnatan.inventoryframework.runtime.view;
+
+import java.util.Arrays;
+import me.devnatan.inventoryframework.View;
+import me.devnatan.inventoryframework.ViewConfigBuilder;
+import me.devnatan.inventoryframework.context.Context;
+import me.devnatan.inventoryframework.context.RenderContext;
+import me.devnatan.inventoryframework.context.SlotClickContext;
+import me.devnatan.inventoryframework.context.SlotRenderContext;
+import me.devnatan.inventoryframework.state.MutableIntState;
+import me.devnatan.inventoryframework.state.timer.Timer;
+import me.devnatan.inventoryframework.state.timer.TimerState;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+
+public class TimerSample extends View {
+
+    private final MutableIntState countState = mutableState(0);
+    private final TimerState timerState = timerState(20);
+
+    @Override
+    public void onInit(@NotNull ViewConfigBuilder config) {
+        config.cancelOnClick().title("Timer (?)").scheduleUpdate(timerState);
+    }
+
+    @Override
+    public void onFirstRender(@NotNull RenderContext render) {
+        render.firstSlot()
+                .onRender(this::onClockItemRender)
+                .onClick(this::onClockItemClick)
+                .updateOnStateChange(timerState);
+
+        render.lastSlot()
+                .onRender(this::onIntervalItemRender)
+                .onClick(this::onIntervalItemClick)
+                .updateOnStateChange(timerState);
+    }
+
+    @Override
+    public void onUpdate(@NotNull Context update) {
+        final int count = countState.increment(update);
+        final String pauseSuffix = timerState.get(update).isPaused() ? " [paused]" : "";
+        update.updateTitleForPlayer("Timer (" + count + ")" + pauseSuffix);
+    }
+
+    private void onClockItemRender(@NotNull SlotRenderContext render) {
+        final Timer timer = timerState.get(render);
+
+        final ItemStack item = new ItemStack(Material.CLOCK);
+        final ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(timer.isPaused() ? "Click to resume" : "Click to pause");
+        item.setItemMeta(meta);
+        render.setItem(item);
+    }
+
+    private void onClockItemClick(@NotNull SlotClickContext click) {
+        final Timer timer = timerState.get(click);
+        final boolean paused = timer.pause();
+        click.getPlayer().sendMessage(paused ? "Timer paused" : "Timer resumed");
+    }
+
+    private void onIntervalItemRender(@NotNull SlotRenderContext render) {
+        final Timer timer = timerState.get(render);
+
+        final ItemStack item = new ItemStack(Material.ARROW, (int) Math.max(timer.currentInterval() / 20, 1));
+        final ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName("Current update interval");
+        meta.setLore(Arrays.asList(
+                "Initial: " + timer.initialInterval() + " ticks", "Current: " + timer.currentInterval() + " ticks"));
+        item.setItemMeta(meta);
+        render.setItem(item);
+    }
+
+    private void onIntervalItemClick(@NotNull SlotClickContext click) {
+        final Timer timer = timerState.get(click);
+        final long newInterval = (timer.currentInterval() % 100) + 20;
+        timer.changeInterval(newInterval);
+        click.getPlayer().sendMessage("Timer interval changed to " + newInterval + " ticks");
+    }
+}

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/ViewConfig.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/ViewConfig.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import me.devnatan.inventoryframework.context.IFContext;
+import me.devnatan.inventoryframework.state.timer.TimerState;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -30,6 +31,7 @@ public class ViewConfig {
     private final Set<Modifier> modifiers;
     private final long updateIntervalInTicks, interactionDelayInMillis;
     private final boolean transitiveInitialData;
+    private final TimerState updateIntervalState;
 
     public ViewConfig(
             Object title,
@@ -40,7 +42,8 @@ public class ViewConfig {
             Set<Modifier> modifiers,
             long updateIntervalInTicks,
             long interactionDelayInMillis,
-            boolean transitiveInitialData) {
+            boolean transitiveInitialData,
+            TimerState updateIntervalState) {
         this.title = title;
         this.size = size;
         this.type = type;
@@ -50,6 +53,7 @@ public class ViewConfig {
         this.updateIntervalInTicks = updateIntervalInTicks;
         this.interactionDelayInMillis = interactionDelayInMillis;
         this.transitiveInitialData = transitiveInitialData;
+        this.updateIntervalState = updateIntervalState;
     }
 
     public Object getTitle() {
@@ -86,6 +90,11 @@ public class ViewConfig {
 
     public boolean isTransitiveInitialData() {
         return transitiveInitialData;
+    }
+
+    @Nullable
+    public TimerState getUpdateIntervalState() {
+        return updateIntervalState;
     }
 
     @VisibleForTesting
@@ -146,7 +155,8 @@ public class ViewConfig {
                 merge(other, ViewConfig::getModifiers, value -> value != null && !value.isEmpty()),
                 merge(other, ViewConfig::getUpdateIntervalInTicks, value -> value != 0),
                 merge(other, ViewConfig::getInteractionDelayInMillis, value -> value != 0),
-                merge(other, ViewConfig::isTransitiveInitialData));
+                merge(other, ViewConfig::isTransitiveInitialData),
+                merge(other, ViewConfig::getUpdateIntervalState, Objects::nonNull));
     }
 
     private <T> T merge(ViewConfig other, Function<ViewConfig, T> retriever) {
@@ -237,7 +247,8 @@ public class ViewConfig {
                 && Objects.equals(getOptions(), that.getOptions())
                 && Arrays.equals(getLayout(), that.getLayout())
                 && Objects.equals(getModifiers(), that.getModifiers())
-                && isTransitiveInitialData() == that.isTransitiveInitialData();
+                && isTransitiveInitialData() == that.isTransitiveInitialData()
+                && Objects.equals(getUpdateIntervalState(), that.getUpdateIntervalState());
     }
 
     @Override
@@ -250,7 +261,8 @@ public class ViewConfig {
                 getModifiers(),
                 getUpdateIntervalInTicks(),
                 getInteractionDelayInMillis(),
-                isTransitiveInitialData());
+                isTransitiveInitialData(),
+                getUpdateIntervalState());
         result = 31 * result + Arrays.hashCode(getLayout());
         return result;
     }
@@ -266,6 +278,7 @@ public class ViewConfig {
                 + modifiers + ", updateIntervalInTicks="
                 + updateIntervalInTicks + ", interactionDelayInMillis="
                 + interactionDelayInMillis + ", transitiveInitialData="
-                + transitiveInitialData + "}";
+                + transitiveInitialData + ", updateIntervalState="
+                + updateIntervalState + "}";
     }
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/ViewConfigBuilder.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/ViewConfigBuilder.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import me.devnatan.inventoryframework.exception.InvalidLayoutException;
+import me.devnatan.inventoryframework.state.timer.TimerState;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -31,6 +32,7 @@ public final class ViewConfigBuilder {
     private String[] layout = null;
     private final Set<ViewConfig.Modifier> modifiers = new HashSet<>();
     private long updateIntervalInTicks, interactionDelayInMillis;
+    private TimerState updateIntervalState;
     private boolean transitiveInitialData;
 
     /**
@@ -201,6 +203,25 @@ public final class ViewConfigBuilder {
     }
 
     /**
+     * Schedules the view to update on every {@link TimerState timer} loop.
+     * <p>
+     * Unlike {@link #scheduleUpdate(long)}, the given timer can have its interval changed and be
+     * paused and resumed at runtime, without opening a new view.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param timerState The timer state that will drive the scheduled updates.
+     * @return This configuration builder.
+     * @see <a href="https://github.com/DevNatan/inventory-framework/wiki/scheduled-updates">Scheduled Updates on Wiki</a>
+     */
+    @ApiStatus.Experimental
+    public ViewConfigBuilder scheduleUpdate(@NotNull TimerState timerState) {
+        this.updateIntervalState = timerState;
+        return this;
+    }
+
+    /**
      * Waits a fixed delay before any player interaction.
      * <p>
      * Interactions called before delay completion are cancelled.
@@ -256,7 +277,8 @@ public final class ViewConfigBuilder {
                 getModifiers(),
                 getUpdateIntervalInTicks(),
                 getInteractionDelayInMillis(),
-                transitiveInitialData);
+                transitiveInitialData,
+                getUpdateIntervalState());
     }
 
     public static boolean isTitleAsComponentSupported() {
@@ -289,6 +311,10 @@ public final class ViewConfigBuilder {
 
     long getUpdateIntervalInTicks() {
         return updateIntervalInTicks;
+    }
+
+    TimerState getUpdateIntervalState() {
+        return updateIntervalState;
     }
 
     long getInteractionDelayInMillis() {

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/state/StateAccess.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/state/StateAccess.java
@@ -11,6 +11,7 @@ import me.devnatan.inventoryframework.component.PaginationStateBuilder;
 import me.devnatan.inventoryframework.component.PaginationValueConsumer;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.context.IFOpenContext;
+import me.devnatan.inventoryframework.state.timer.TimerState;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -172,6 +173,27 @@ public interface StateAccess<
      * @return A state computed with an initial opening data value.
      */
     <T> MutableState<T> initialState(@NotNull String key);
+
+    /**
+     * Creates a new timer state.
+     * <p>
+     * Unlike {@link me.devnatan.inventoryframework.ViewConfigBuilder#scheduleUpdate(long)}, the
+     * timer obtained from this state can have its interval changed and can be paused and resumed
+     * at runtime, without opening a new view.
+     * <pre>{@code
+     * TimerState timer = timerState(20);
+     *
+     * config.scheduleUpdate(timer);
+     * }</pre>
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param intervalInTicks The initial interval, in ticks, the timer will run at.
+     * @return A new timer state.
+     */
+    @ApiStatus.Experimental
+    TimerState timerState(long intervalInTicks);
 
     /**
      * Creates a new immutable pagination with static data source.

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/state/timer/Timer.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/state/timer/Timer.java
@@ -1,0 +1,62 @@
+package me.devnatan.inventoryframework.state.timer;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A timer whose interval and pause state can be controlled at runtime.
+ * <p>
+ * Unlike {@link me.devnatan.inventoryframework.ViewConfigBuilder#scheduleUpdate(long)}, a timer
+ * lets the developer pause it, resume it and change its interval without having to open a new
+ * view.
+ *
+ * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+ * such API may be changed or may be removed completely in any further release. </i></b>
+ */
+@ApiStatus.Experimental
+public interface Timer {
+
+    /**
+     * Called every base tick by the underlying scheduled job.
+     * <p>
+     * This is an internal detail of the timer implementation, it should not be called directly.
+     */
+    @ApiStatus.Internal
+    void loop();
+
+    /**
+     * The interval, in ticks, that this timer was created with.
+     *
+     * @return The initial interval in ticks.
+     */
+    long initialInterval();
+
+    /**
+     * The interval, in ticks, that this timer is currently running at.
+     *
+     * @return The current interval in ticks.
+     */
+    long currentInterval();
+
+    /**
+     * Changes the interval of this timer.
+     * <p>
+     * Takes effect immediately, the timer's elapsed time is reset.
+     *
+     * @param interval The new interval in ticks.
+     */
+    void changeInterval(long interval);
+
+    /**
+     * Whether this timer is currently paused.
+     *
+     * @return {@code true} if paused, {@code false} otherwise.
+     */
+    boolean isPaused();
+
+    /**
+     * Toggles the paused state of this timer.
+     *
+     * @return The new paused state, i.e. {@code true} if the timer is now paused.
+     */
+    boolean pause();
+}

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/state/timer/TimerState.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/state/timer/TimerState.java
@@ -1,0 +1,13 @@
+package me.devnatan.inventoryframework.state.timer;
+
+import me.devnatan.inventoryframework.state.State;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A state that holds a {@link Timer}.
+ *
+ * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+ * such API may be changed or may be removed completely in any further release. </i></b>
+ */
+@ApiStatus.Experimental
+public interface TimerState extends State<Timer> {}

--- a/inventory-framework-api/src/main/kotlin/me/devnatan/inventoryframework/state/StateAccess.kt
+++ b/inventory-framework-api/src/main/kotlin/me/devnatan/inventoryframework/state/StateAccess.kt
@@ -1,0 +1,17 @@
+@file:JvmSynthetic
+
+package me.devnatan.inventoryframework.state
+
+import me.devnatan.inventoryframework.state.timer.TimerState
+import kotlin.time.Duration
+
+private const val SECONDS_TO_TICKS_DIV = 20L
+
+/**
+ * Creates a new timer state.
+ *
+ * @param interval The initial interval the timer will run at.
+ * @return A new timer state.
+ * @see StateAccess.timerState
+ */
+public fun StateAccess<*, *>.timerState(interval: Duration): TimerState = timerState(interval.inWholeSeconds * SECONDS_TO_TICKS_DIV)

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/ScheduledUpdateStartInterceptor.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/ScheduledUpdateStartInterceptor.java
@@ -6,8 +6,13 @@ import me.devnatan.inventoryframework.RootView;
 import me.devnatan.inventoryframework.VirtualView;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.internal.Job;
+import me.devnatan.inventoryframework.state.timer.Timer;
+import me.devnatan.inventoryframework.state.timer.TimerState;
 
 public final class ScheduledUpdateStartInterceptor implements PipelineInterceptor<VirtualView> {
+
+    /** Base cadence, in ticks, the timer-driven job runs at so a {@link Timer}'s own interval can change at runtime. */
+    private static final long TIMER_BASE_INTERVAL_IN_TICKS = 1;
 
     @Override
     public void intercept(PipelineContext<VirtualView> pipeline, VirtualView subject) {
@@ -16,8 +21,9 @@ public final class ScheduledUpdateStartInterceptor implements PipelineIntercepto
         final IFContext context = (IFContext) subject;
         final RootView root = context.getRoot();
         final long updateIntervalInTicks = context.getConfig().getUpdateIntervalInTicks();
+        final TimerState updateIntervalState = context.getConfig().getUpdateIntervalState();
 
-        if (updateIntervalInTicks == 0) {
+        if (updateIntervalInTicks == 0 && updateIntervalState == null) {
             return;
         }
 
@@ -25,10 +31,20 @@ public final class ScheduledUpdateStartInterceptor implements PipelineIntercepto
             return;
         }
 
-        final Job updateJob = root.getElementFactory().scheduleJobInterval(root, updateIntervalInTicks, () -> {
-            final List<IFContext> contextList = new ArrayList<>(root.getInternalContexts());
-            contextList.stream().filter(IFContext::isActive).forEach(IFContext::update);
-        });
+        final Job updateJob;
+        if (updateIntervalState != null) {
+            updateJob = root.getElementFactory().scheduleJobInterval(root, TIMER_BASE_INTERVAL_IN_TICKS, () -> {
+                final List<IFContext> contextList = new ArrayList<>(root.getInternalContexts());
+                contextList.stream()
+                        .filter(IFContext::isActive)
+                        .forEach(activeContext -> ((Timer) updateIntervalState.get(activeContext)).loop());
+            });
+        } else {
+            updateJob = root.getElementFactory().scheduleJobInterval(root, updateIntervalInTicks, () -> {
+                final List<IFContext> contextList = new ArrayList<>(root.getInternalContexts());
+                contextList.stream().filter(IFContext::isActive).forEach(IFContext::update);
+            });
+        }
         root.setScheduledUpdateJob(updateJob);
         updateJob.start();
     }

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/ScheduledUpdateStopInterceptor.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/ScheduledUpdateStopInterceptor.java
@@ -13,7 +13,7 @@ public final class ScheduledUpdateStopInterceptor implements PipelineInterceptor
 
         final IFCloseContext context = (IFCloseContext) subject;
         final long updateIntervalInTicks = context.getConfig().getUpdateIntervalInTicks();
-        if (updateIntervalInTicks == 0) {
+        if (updateIntervalInTicks == 0 && context.getConfig().getUpdateIntervalState() == null) {
             return;
         }
 

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/state/StateAccessImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/state/StateAccessImpl.java
@@ -14,6 +14,8 @@ import me.devnatan.inventoryframework.component.PaginationStateBuilder;
 import me.devnatan.inventoryframework.component.PaginationValueConsumer;
 import me.devnatan.inventoryframework.context.IFContext;
 import me.devnatan.inventoryframework.internal.ElementFactory;
+import me.devnatan.inventoryframework.state.timer.TimerImpl;
+import me.devnatan.inventoryframework.state.timer.TimerState;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -124,6 +126,17 @@ public final class StateAccessImpl<
         final long id = State.next();
         final MutableState<T> state =
                 new BaseMutableState<>(id, (host, valueState) -> new InitialDataStateValue(valueState, host, key));
+        this.stateRegistry.registerState(state, this);
+
+        return state;
+    }
+
+    @Override
+    public TimerState timerState(long intervalInTicks) {
+        final long id = State.next();
+        final StateValueFactory factory =
+                (host, state) -> new ImmutableValue(state, new TimerImpl(intervalInTicks, ((IFContext) host)::update));
+        final TimerState state = new TimerStateImpl(id, factory);
         this.stateRegistry.registerState(state, this);
 
         return state;

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/state/TimerStateImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/state/TimerStateImpl.java
@@ -1,0 +1,17 @@
+package me.devnatan.inventoryframework.state;
+
+import me.devnatan.inventoryframework.state.timer.Timer;
+import me.devnatan.inventoryframework.state.timer.TimerState;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * <b><i> This is an internal inventory-framework API that should not be used from outside of
+ * this library. No compatibility guarantees are provided. </i></b>
+ */
+@ApiStatus.Internal
+public final class TimerStateImpl extends BaseState<Timer> implements TimerState {
+
+    public TimerStateImpl(long id, StateValueFactory valueFactory) {
+        super(id, valueFactory);
+    }
+}

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/state/timer/TimerImpl.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/state/timer/TimerImpl.java
@@ -1,0 +1,69 @@
+package me.devnatan.inventoryframework.state.timer;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Default {@link Timer} implementation.
+ * <p>
+ * A {@link #loop()} call is expected to happen every base tick, this timer tracks its own
+ * elapsed ticks and fires {@code onElapsed} once {@link #currentInterval()} ticks have passed,
+ * so that changing the interval or pausing takes effect immediately without needing to
+ * reschedule the underlying platform job.
+ *
+ * <p><b><i> This is an internal inventory-framework API that should not be used from outside of
+ * this library. No compatibility guarantees are provided. </i></b>
+ */
+@ApiStatus.Internal
+public final class TimerImpl implements Timer {
+
+    private final long initialInterval;
+    private final Runnable onElapsed;
+    private long currentInterval;
+    private long elapsedTicks;
+    private boolean paused;
+
+    public TimerImpl(long initialInterval, @NotNull Runnable onElapsed) {
+        this.initialInterval = initialInterval;
+        this.currentInterval = initialInterval;
+        this.onElapsed = onElapsed;
+    }
+
+    @Override
+    public void loop() {
+        if (paused || currentInterval <= 0) return;
+
+        elapsedTicks++;
+        if (elapsedTicks < currentInterval) return;
+
+        elapsedTicks = 0;
+        onElapsed.run();
+    }
+
+    @Override
+    public long initialInterval() {
+        return initialInterval;
+    }
+
+    @Override
+    public long currentInterval() {
+        return currentInterval;
+    }
+
+    @Override
+    public void changeInterval(long interval) {
+        this.currentInterval = interval;
+        this.elapsedTicks = 0;
+    }
+
+    @Override
+    public boolean isPaused() {
+        return paused;
+    }
+
+    @Override
+    public boolean pause() {
+        paused = !paused;
+        return paused;
+    }
+}

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -11,7 +11,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
 import me.devnatan.inventoryframework.component.ComponentFactory;
 import me.devnatan.inventoryframework.component.ItemComponentBuilder;
 import me.devnatan.inventoryframework.component.Pagination;
@@ -51,6 +50,7 @@ import me.devnatan.inventoryframework.state.State;
 import me.devnatan.inventoryframework.state.StateAccess;
 import me.devnatan.inventoryframework.state.StateAccessImpl;
 import me.devnatan.inventoryframework.state.StateValue;
+import me.devnatan.inventoryframework.state.timer.TimerState;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -690,6 +690,12 @@ public abstract class PlatformView<
     public final <T> MutableState<T> initialState(@NotNull String key) {
         requireNotInitialized();
         return stateAccess.initialState(key);
+    }
+
+    @Override
+    public final TimerState timerState(long intervalInTicks) {
+        requireNotInitialized();
+        return stateAccess.timerState(intervalInTicks);
     }
 
     @Override


### PR DESCRIPTION
Derived from #736

A new state that holds a timer value. Previously the only way to "use time" in IF views was through scheduleUpdate that calls view's update() automatically at a fixed interval specified by the developer, the developer itself didn't have any control over it.

The purpose of that timer state is to give developer control of anything related to time in Inventory Framework views like to upcoming https://github.com/DevNatan/inventory-framework/issues/78 and allow them to pause; change interval without opening a new inventory; create multiple timers for multiple things; call another context methods not only update() like chain a [Ref](https://github.com/DevNatan/inventory-framework/wiki/refs-api) to a Component and update it programatically and so on.

Closes https://github.com/devnatan/inventory-framework/issues/369