### PR TITLE
Entire row or column slot assignment feature

### DIFF
--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/SamplePlugin.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/SamplePlugin.java
@@ -23,7 +23,8 @@ public class SamplePlugin extends JavaPlugin {
                         new SimplePagination(),
                         new AutoUpdate(),
                         new PaginationOrientation(),
-                        new TimerSample())
+                        new TimerSample(),
+                        new RowColumnSample())
                 .register();
 
         IFExampleCommandExecutor command = new IFExampleCommandExecutor(viewFrame);

--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/commands/IFExampleCommandExecutor.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/commands/IFExampleCommandExecutor.java
@@ -10,6 +10,7 @@ import me.devnatan.inventoryframework.runtime.view.AnvilInputSample;
 import me.devnatan.inventoryframework.runtime.view.AutoUpdate;
 import me.devnatan.inventoryframework.runtime.view.Failing;
 import me.devnatan.inventoryframework.runtime.view.PaginationOrientation;
+import me.devnatan.inventoryframework.runtime.view.RowColumnSample;
 import me.devnatan.inventoryframework.runtime.view.SimplePagination;
 import me.devnatan.inventoryframework.runtime.view.TimerSample;
 import org.bukkit.command.Command;
@@ -32,6 +33,7 @@ public class IFExampleCommandExecutor implements CommandExecutor, TabCompleter {
         views.put("auto-update", AutoUpdate.class);
         views.put("pagination", PaginationOrientation.class);
         views.put("timer", TimerSample.class);
+        views.put("row-column", RowColumnSample.class);
     }
 
     private final ViewFrame viewFrame;

--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/RowColumnSample.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/RowColumnSample.java
@@ -16,14 +16,17 @@ public class RowColumnSample extends View {
 
     @Override
     public void onFirstRender(@NotNull RenderContext render) {
+        final int columnsCount = render.getContainer().getColumnsCount();
+        final int rowsCount = render.getContainer().getRowsCount();
+
         // Fills the whole first row, left to right.
-        for (int i = 0; i < 9; i++) {
+        for (int i = 0; i < columnsCount; i++) {
             render.row(1).withItem(new ItemStack(Material.LIME_STAINED_GLASS_PANE));
         }
 
         // Fills the whole last column, top to bottom.
-        for (int i = 0; i < 4; i++) {
-            render.column(9).withItem(new ItemStack(Material.ORANGE_STAINED_GLASS_PANE));
+        for (int i = 0; i < rowsCount; i++) {
+            render.column(columnsCount).withItem(new ItemStack(Material.ORANGE_STAINED_GLASS_PANE));
         }
     }
 }

--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/RowColumnSample.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/RowColumnSample.java
@@ -1,0 +1,29 @@
+package me.devnatan.inventoryframework.runtime.view;
+
+import me.devnatan.inventoryframework.View;
+import me.devnatan.inventoryframework.ViewConfigBuilder;
+import me.devnatan.inventoryframework.context.RenderContext;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+public class RowColumnSample extends View {
+
+    @Override
+    public void onInit(@NotNull ViewConfigBuilder config) {
+        config.cancelOnClick().title("Row & Column").size(4);
+    }
+
+    @Override
+    public void onFirstRender(@NotNull RenderContext render) {
+        // Fills the whole first row, left to right.
+        for (int i = 0; i < 9; i++) {
+            render.row(1).withItem(new ItemStack(Material.LIME_STAINED_GLASS_PANE));
+        }
+
+        // Fills the whole last column, top to bottom.
+        for (int i = 0; i < 4; i++) {
+            render.column(9).withItem(new ItemStack(Material.ORANGE_STAINED_GLASS_PANE));
+        }
+    }
+}

--- a/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/RowColumnSample.java
+++ b/examples/paper/src/main/java/me/devnatan/inventoryframework/runtime/view/RowColumnSample.java
@@ -21,12 +21,12 @@ public class RowColumnSample extends View {
 
         // Fills the whole first row, left to right.
         for (int i = 0; i < columnsCount; i++) {
-            render.row(1).withItem(new ItemStack(Material.LIME_STAINED_GLASS_PANE));
+            render.firstRow().withItem(new ItemStack(Material.LIME_STAINED_GLASS_PANE));
         }
 
         // Fills the whole last column, top to bottom.
         for (int i = 0; i < rowsCount; i++) {
-            render.column(columnsCount).withItem(new ItemStack(Material.ORANGE_STAINED_GLASS_PANE));
+            render.lastColumn().withItem(new ItemStack(Material.ORANGE_STAINED_GLASS_PANE));
         }
     }
 }

--- a/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFRenderContext.java
+++ b/inventory-framework-api/src/main/java/me/devnatan/inventoryframework/context/IFRenderContext.java
@@ -1,6 +1,7 @@
 package me.devnatan.inventoryframework.context;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.BiFunction;
 import me.devnatan.inventoryframework.ViewContainer;
 import me.devnatan.inventoryframework.component.ComponentFactory;
@@ -39,6 +40,20 @@ public interface IFRenderContext extends IFConfinedContext {
      */
     @ApiStatus.Internal
     List<BiFunction<Integer, Integer, ComponentFactory>> getAvailableSlotFactories();
+
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    Map<Integer, List<BiFunction<Integer, Integer, ComponentFactory>>> getRowSlotFactories();
+
+    /**
+     * <b><i> This is an internal inventory-framework API that should not be used from outside of
+     * this library. No compatibility guarantees are provided. </i></b>
+     */
+    @ApiStatus.Internal
+    Map<Integer, List<BiFunction<Integer, Integer, ComponentFactory>>> getColumnSlotFactories();
 
     /**
      * The container of this context.

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/AvailableSlotInterceptor.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/AvailableSlotInterceptor.java
@@ -117,7 +117,7 @@ public final class AvailableSlotInterceptor implements PipelineInterceptor<Virtu
         return result;
     }
 
-    private boolean isSlotNotAvailableForAutoFilling(IFRenderContext context, int slot) {
+    static boolean isSlotNotAvailableForAutoFilling(IFRenderContext context, int slot) {
         if (!context.getContainer().getType().canPlayerInteractOn(slot)) return true;
         if (context.getContainer().getSize() >= slot) return false;
 

--- a/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/RowColumnSlotInterceptor.java
+++ b/inventory-framework-core/src/main/java/me/devnatan/inventoryframework/pipeline/RowColumnSlotInterceptor.java
@@ -1,0 +1,80 @@
+package me.devnatan.inventoryframework.pipeline;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import me.devnatan.inventoryframework.VirtualView;
+import me.devnatan.inventoryframework.component.ComponentFactory;
+import me.devnatan.inventoryframework.context.IFRenderContext;
+import me.devnatan.inventoryframework.exception.SlotFillExceededException;
+
+/**
+ * Resolves items registered through {@code row(int)}/{@code column(int)} to the next available
+ * slot within the target row/column, in order, skipping slots that are already occupied.
+ */
+public final class RowColumnSlotInterceptor implements PipelineInterceptor<VirtualView> {
+
+    @Override
+    public void intercept(PipelineContext<VirtualView> pipeline, VirtualView subject) {
+        if (!(subject instanceof IFRenderContext)) return;
+
+        final IFRenderContext context = (IFRenderContext) subject;
+        resolveRows(context);
+        resolveColumns(context);
+    }
+
+    private void resolveRows(IFRenderContext context) {
+        final int columnsCount = context.getContainer().getColumnsCount();
+
+        for (final Map.Entry<Integer, List<BiFunction<Integer, Integer, ComponentFactory>>> entry :
+                context.getRowSlotFactories().entrySet()) {
+            final int row = entry.getKey();
+            final int start = Math.max(row - 1, 0) * columnsCount;
+
+            final List<Integer> candidateSlots = new ArrayList<>(columnsCount);
+            for (int i = 0; i < columnsCount; i++) candidateSlots.add(start + i);
+
+            resolveBounded(context, entry.getValue(), candidateSlots, "row", row);
+        }
+    }
+
+    private void resolveColumns(IFRenderContext context) {
+        final int columnsCount = context.getContainer().getColumnsCount();
+        final int rowsCount = context.getContainer().getRowsCount();
+
+        for (final Map.Entry<Integer, List<BiFunction<Integer, Integer, ComponentFactory>>> entry :
+                context.getColumnSlotFactories().entrySet()) {
+            final int column = entry.getKey();
+            final int base = Math.max(column - 1, 0);
+
+            final List<Integer> candidateSlots = new ArrayList<>(rowsCount);
+            for (int i = 0; i < rowsCount; i++) candidateSlots.add(base + i * columnsCount);
+
+            resolveBounded(context, entry.getValue(), candidateSlots, "column", column);
+        }
+    }
+
+    private void resolveBounded(
+            IFRenderContext context,
+            List<BiFunction<Integer, Integer, ComponentFactory>> factories,
+            List<Integer> candidateSlots,
+            String axis,
+            int axisIndex) {
+        int cursor = 0;
+        for (int i = 0; i < factories.size(); i++) {
+            while (cursor < candidateSlots.size()
+                    && AvailableSlotInterceptor.isSlotNotAvailableForAutoFilling(context, candidateSlots.get(cursor)))
+                cursor++;
+
+            if (cursor >= candidateSlots.size())
+                throw new SlotFillExceededException(String.format(
+                        "Capacity to accommodate items in %s %d has been exceeded (%d slots available, "
+                                + "tried to fill item at index %d).",
+                        axis, axisIndex, candidateSlots.size(), i));
+
+            final int slot = candidateSlots.get(cursor++);
+            context.addComponent(factories.get(i).apply(i, slot).create());
+        }
+    }
+}

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/PlatformView.java
@@ -38,6 +38,7 @@ import me.devnatan.inventoryframework.pipeline.PlatformInitInterceptor;
 import me.devnatan.inventoryframework.pipeline.PlatformOpenInterceptor;
 import me.devnatan.inventoryframework.pipeline.PlatformRenderInterceptor;
 import me.devnatan.inventoryframework.pipeline.PlatformUpdateHandlerInterceptor;
+import me.devnatan.inventoryframework.pipeline.RowColumnSlotInterceptor;
 import me.devnatan.inventoryframework.pipeline.ScheduledUpdateStartInterceptor;
 import me.devnatan.inventoryframework.pipeline.ScheduledUpdateStopInterceptor;
 import me.devnatan.inventoryframework.pipeline.StandardPipelinePhases;
@@ -615,6 +616,7 @@ public abstract class PlatformView<
         pipeline.intercept(StandardPipelinePhases.LAYOUT_RESOLUTION, new LayoutResolutionInterceptor());
         pipeline.intercept(StandardPipelinePhases.FIRST_RENDER, new PlatformRenderInterceptor());
         pipeline.intercept(StandardPipelinePhases.FIRST_RENDER, new LayoutRenderInterceptor());
+        pipeline.intercept(StandardPipelinePhases.FIRST_RENDER, new RowColumnSlotInterceptor());
         pipeline.intercept(StandardPipelinePhases.FIRST_RENDER, new AvailableSlotInterceptor());
         pipeline.intercept(StandardPipelinePhases.FIRST_RENDER, new FirstRenderInterceptor());
         pipeline.intercept(StandardPipelinePhases.VIEWER_ADDED, new ScheduledUpdateStartInterceptor());

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformRenderContext.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformRenderContext.java
@@ -4,6 +4,7 @@ import static me.devnatan.inventoryframework.utils.SlotConverter.convertSlot;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -43,6 +44,10 @@ public abstract class PlatformRenderContext<T extends ItemComponentBuilder<T, C>
     private final List<ComponentFactory> componentBuilders = new ArrayList<>();
     private final List<LayoutSlot> layoutSlots = new ArrayList<>();
     private final List<BiFunction<Integer, Integer, ComponentFactory>> availableSlotFactories = new ArrayList<>();
+    private final Map<Integer, List<BiFunction<Integer, Integer, ComponentFactory>>> rowSlotFactories =
+            new LinkedHashMap<>();
+    private final Map<Integer, List<BiFunction<Integer, Integer, ComponentFactory>>> columnSlotFactories =
+            new LinkedHashMap<>();
 
     PlatformRenderContext(
             @NotNull UUID id,
@@ -153,6 +158,88 @@ public abstract class PlatformRenderContext<T extends ItemComponentBuilder<T, C>
      */
     public final void availableSlot(@NotNull BiConsumer<Integer, T> factory) {
         availableSlotFactories.add((index, slot) -> {
+            final T builder = createBuilder();
+            builder.withSlot(slot);
+            factory.accept(index, builder);
+            return (ComponentFactory) builder;
+        });
+    }
+
+    /**
+     * Adds an item in the next available slot of the specified row of this context's container.
+     * <p>
+     * Slots are filled in column order within the row, skipping slots that are already occupied
+     * (e.g. by a layout item). An {@link me.devnatan.inventoryframework.exception.SlotFillExceededException}
+     * is thrown at render time if there are more items than the row can hold.
+     *
+     * @param row The row (1-indexed) to fill.
+     * @return An item builder to configure the item.
+     */
+    public final @NotNull T row(int row) {
+        checkAlignedContainerTypeForSlotAssignment();
+
+        final T builder = createBuilder();
+        rowSlotFactories.computeIfAbsent(row, $ -> new ArrayList<>()).add((index, slot) ->
+                (ComponentFactory) builder.copy().withSlot(slot));
+        return builder;
+    }
+
+    /**
+     * Adds an item in the next available slot of the specified row of this context's container.
+     *
+     * <pre>{@code
+     * row(1, (index, builder) -> builder.withItem(...));
+     * }</pre>
+     *
+     * @param row     The row (1-indexed) to fill.
+     * @param factory A factory to create the item builder to configure the item.
+     *                The first parameter is the iteration index of the available slot within the row.
+     */
+    public final void row(int row, @NotNull BiConsumer<Integer, T> factory) {
+        checkAlignedContainerTypeForSlotAssignment();
+
+        rowSlotFactories.computeIfAbsent(row, $ -> new ArrayList<>()).add((index, slot) -> {
+            final T builder = createBuilder();
+            builder.withSlot(slot);
+            factory.accept(index, builder);
+            return (ComponentFactory) builder;
+        });
+    }
+
+    /**
+     * Adds an item in the next available slot of the specified column of this context's container.
+     * <p>
+     * Slots are filled in row order within the column, skipping slots that are already occupied
+     * (e.g. by a layout item). An {@link me.devnatan.inventoryframework.exception.SlotFillExceededException}
+     * is thrown at render time if there are more items than the column can hold.
+     *
+     * @param column The column (1-indexed) to fill.
+     * @return An item builder to configure the item.
+     */
+    public final @NotNull T column(int column) {
+        checkAlignedContainerTypeForSlotAssignment();
+
+        final T builder = createBuilder();
+        columnSlotFactories.computeIfAbsent(column, $ -> new ArrayList<>()).add((index, slot) ->
+                (ComponentFactory) builder.copy().withSlot(slot));
+        return builder;
+    }
+
+    /**
+     * Adds an item in the next available slot of the specified column of this context's container.
+     *
+     * <pre>{@code
+     * column(1, (index, builder) -> builder.withItem(...));
+     * }</pre>
+     *
+     * @param column  The column (1-indexed) to fill.
+     * @param factory A factory to create the item builder to configure the item.
+     *                The first parameter is the iteration index of the available slot within the column.
+     */
+    public final void column(int column, @NotNull BiConsumer<Integer, T> factory) {
+        checkAlignedContainerTypeForSlotAssignment();
+
+        columnSlotFactories.computeIfAbsent(column, $ -> new ArrayList<>()).add((index, slot) -> {
             final T builder = createBuilder();
             builder.withSlot(slot);
             factory.accept(index, builder);
@@ -276,6 +363,16 @@ public abstract class PlatformRenderContext<T extends ItemComponentBuilder<T, C>
     @Override
     public final List<BiFunction<Integer, Integer, ComponentFactory>> getAvailableSlotFactories() {
         return availableSlotFactories;
+    }
+
+    @Override
+    public final Map<Integer, List<BiFunction<Integer, Integer, ComponentFactory>>> getRowSlotFactories() {
+        return rowSlotFactories;
+    }
+
+    @Override
+    public final Map<Integer, List<BiFunction<Integer, Integer, ComponentFactory>>> getColumnSlotFactories() {
+        return columnSlotFactories;
     }
 
     @Override

--- a/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformRenderContext.java
+++ b/inventory-framework-platform/src/main/java/me/devnatan/inventoryframework/context/PlatformRenderContext.java
@@ -172,9 +172,13 @@ public abstract class PlatformRenderContext<T extends ItemComponentBuilder<T, C>
      * (e.g. by a layout item). An {@link me.devnatan.inventoryframework.exception.SlotFillExceededException}
      * is thrown at render time if there are more items than the row can hold.
      *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
      * @param row The row (1-indexed) to fill.
      * @return An item builder to configure the item.
      */
+    @ApiStatus.Experimental
     public final @NotNull T row(int row) {
         checkAlignedContainerTypeForSlotAssignment();
 
@@ -191,10 +195,14 @@ public abstract class PlatformRenderContext<T extends ItemComponentBuilder<T, C>
      * row(1, (index, builder) -> builder.withItem(...));
      * }</pre>
      *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
      * @param row     The row (1-indexed) to fill.
      * @param factory A factory to create the item builder to configure the item.
      *                The first parameter is the iteration index of the available slot within the row.
      */
+    @ApiStatus.Experimental
     public final void row(int row, @NotNull BiConsumer<Integer, T> factory) {
         checkAlignedContainerTypeForSlotAssignment();
 
@@ -207,15 +215,73 @@ public abstract class PlatformRenderContext<T extends ItemComponentBuilder<T, C>
     }
 
     /**
+     * Adds an item in the next available slot of the first row of this context's container.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @return An item builder to configure the item.
+     */
+    @ApiStatus.Experimental
+    public final @NotNull T firstRow() {
+        return row(1);
+    }
+
+    /**
+     * Adds an item in the next available slot of the first row of this context's container.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param factory A factory to create the item builder to configure the item.
+     *                The first parameter is the iteration index of the available slot within the row.
+     */
+    @ApiStatus.Experimental
+    public final void firstRow(@NotNull BiConsumer<Integer, T> factory) {
+        row(1, factory);
+    }
+
+    /**
+     * Adds an item in the next available slot of the last row of this context's container.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @return An item builder to configure the item.
+     */
+    @ApiStatus.Experimental
+    public final @NotNull T lastRow() {
+        return row(getContainer().getRowsCount());
+    }
+
+    /**
+     * Adds an item in the next available slot of the last row of this context's container.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param factory A factory to create the item builder to configure the item.
+     *                The first parameter is the iteration index of the available slot within the row.
+     */
+    @ApiStatus.Experimental
+    public final void lastRow(@NotNull BiConsumer<Integer, T> factory) {
+        row(getContainer().getRowsCount(), factory);
+    }
+
+    /**
      * Adds an item in the next available slot of the specified column of this context's container.
      * <p>
      * Slots are filled in row order within the column, skipping slots that are already occupied
      * (e.g. by a layout item). An {@link me.devnatan.inventoryframework.exception.SlotFillExceededException}
      * is thrown at render time if there are more items than the column can hold.
      *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
      * @param column The column (1-indexed) to fill.
      * @return An item builder to configure the item.
      */
+    @ApiStatus.Experimental
     public final @NotNull T column(int column) {
         checkAlignedContainerTypeForSlotAssignment();
 
@@ -232,10 +298,14 @@ public abstract class PlatformRenderContext<T extends ItemComponentBuilder<T, C>
      * column(1, (index, builder) -> builder.withItem(...));
      * }</pre>
      *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
      * @param column  The column (1-indexed) to fill.
      * @param factory A factory to create the item builder to configure the item.
      *                The first parameter is the iteration index of the available slot within the column.
      */
+    @ApiStatus.Experimental
     public final void column(int column, @NotNull BiConsumer<Integer, T> factory) {
         checkAlignedContainerTypeForSlotAssignment();
 
@@ -245,6 +315,60 @@ public abstract class PlatformRenderContext<T extends ItemComponentBuilder<T, C>
             factory.accept(index, builder);
             return (ComponentFactory) builder;
         });
+    }
+
+    /**
+     * Adds an item in the next available slot of the first column of this context's container.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @return An item builder to configure the item.
+     */
+    @ApiStatus.Experimental
+    public final @NotNull T firstColumn() {
+        return column(1);
+    }
+
+    /**
+     * Adds an item in the next available slot of the first column of this context's container.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param factory A factory to create the item builder to configure the item.
+     *                The first parameter is the iteration index of the available slot within the column.
+     */
+    @ApiStatus.Experimental
+    public final void firstColumn(@NotNull BiConsumer<Integer, T> factory) {
+        column(1, factory);
+    }
+
+    /**
+     * Adds an item in the next available slot of the last column of this context's container.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @return An item builder to configure the item.
+     */
+    @ApiStatus.Experimental
+    public final @NotNull T lastColumn() {
+        return column(getContainer().getColumnsCount());
+    }
+
+    /**
+     * Adds an item in the next available slot of the last column of this context's container.
+     *
+     * <p><b><i> This API is experimental and is not subject to the general compatibility guarantees
+     * such API may be changed or may be removed completely in any further release. </i></b>
+     *
+     * @param factory A factory to create the item builder to configure the item.
+     *                The first parameter is the iteration index of the available slot within the column.
+     */
+    @ApiStatus.Experimental
+    public final void lastColumn(@NotNull BiConsumer<Integer, T> factory) {
+        column(getContainer().getColumnsCount(), factory);
     }
 
     /**

--- a/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/context/MockRenderIFContext.java
+++ b/inventory-framework-test/src/main/java/me/devnatan/inventoryframework/context/MockRenderIFContext.java
@@ -3,7 +3,9 @@ package me.devnatan.inventoryframework.context;
 import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.BiFunction;
 import me.devnatan.inventoryframework.RootView;
@@ -39,6 +41,16 @@ public class MockRenderIFContext extends AbstractIFContext implements IFRenderCo
     @Override
     public List<BiFunction<Integer, Integer, ComponentFactory>> getAvailableSlotFactories() {
         return new ArrayList<>();
+    }
+
+    @Override
+    public Map<Integer, List<BiFunction<Integer, Integer, ComponentFactory>>> getRowSlotFactories() {
+        return new HashMap<>();
+    }
+
+    @Override
+    public Map<Integer, List<BiFunction<Integer, Integer, ComponentFactory>>> getColumnSlotFactories() {
+        return new HashMap<>();
     }
 
     @Override


### PR DESCRIPTION
Adds a way to assign multiple items dynamically in deterministic order without requiring a configured layout (layoutSlot) or accepting whatever slot happens to be free container-wide (availableSlot).

See https://github.com/devnatan/inventory-framework/wiki/basic-usage#filling-a-row-or-column