### PR TITLE
Remove "intellij" from IJ plugin identifier

### DIFF
--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,5 +1,5 @@
 <idea-plugin>
-    <id>me.devnatan.inventoryframework.intellij</id>
+    <id>me.devnatan.inventoryframework</id>
     <name>Inventory Framework</name>
     <vendor url="https://github.com/DevNatan/inventory-framework">DevNatan</vendor>
 


### PR DESCRIPTION
Not allowed by JetBrains.