### PR TITLE
Preview support for explicit `slot(row, column)` in IntelliJ plugin

### DIFF
--- a/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/ItemExtractor.kt
+++ b/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/ItemExtractor.kt
@@ -121,10 +121,19 @@ object ItemExtractor {
     private fun resolveDirectItemCall(node: UCallExpression, rows: Int, columns: Int): Pair<SlotTarget, UExpression>? {
         val args = node.valueArguments
         return when (node.methodName) {
-            "slot" -> if (args.size == 2) {
-                val index = args[0].evaluate() as? Int ?: return null
-                SlotTarget.Indices(listOf(index)) to args[1]
-            } else null
+            "slot" -> when (args.size) {
+                2 -> {
+                    val index = args[0].evaluate() as? Int ?: return null
+                    SlotTarget.Indices(listOf(index)) to args[1]
+                }
+                3 -> {
+                    val row = args[0].evaluate() as? Int ?: return null
+                    val column = args[1].evaluate() as? Int ?: return null
+                    val index = SlotTargetResolver.slotIndex(row, column, rows, columns) ?: return null
+                    SlotTarget.Indices(listOf(index)) to args[2]
+                }
+                else -> null
+            }
             "firstSlot" -> if (args.size == 1) SlotTarget.Indices(listOf(0)) to args[0] else null
             "lastSlot" -> if (args.size == 1) SlotTarget.Indices(listOf(rows * columns - 1)) to args[0] else null
             "layoutSlot" -> if (args.size == 2) {

--- a/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/SlotTargetResolver.kt
+++ b/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/SlotTargetResolver.kt
@@ -25,7 +25,15 @@ internal object SlotTargetResolver {
     private fun resolveDirect(call: UCallExpression, rows: Int, columns: Int): SlotTarget? {
         val args = call.valueArguments
         return when (call.methodName) {
-            "slot" -> (args.getOrNull(0)?.evaluate() as? Int)?.let { SlotTarget.Indices(listOf(it)) }
+            "slot" -> when (args.size) {
+                1 -> (args[0].evaluate() as? Int)?.let { SlotTarget.Indices(listOf(it)) }
+                2 -> {
+                    val row = args[0].evaluate() as? Int ?: return null
+                    val column = args[1].evaluate() as? Int ?: return null
+                    slotIndex(row, column, rows, columns)?.let { SlotTarget.Indices(listOf(it)) }
+                }
+                else -> null
+            }
             "firstSlot" -> SlotTarget.Indices(listOf(0))
             "lastSlot" -> SlotTarget.Indices(listOf(rows * columns - 1))
             "layoutSlot" -> (args.getOrNull(0)?.evaluate() as? Char)?.let { SlotTarget.Layout(it) }
@@ -37,6 +45,13 @@ internal object SlotTargetResolver {
             "lastColumn" -> columnIndices(columns, rows, columns)
             else -> null
         }
+    }
+
+    // Mirrors SlotConverter#convertSlot in the core module: 1-indexed row/column to a 0-indexed slot.
+    fun slotIndex(row1Indexed: Int, column1Indexed: Int, rows: Int, columns: Int): Int? {
+        if (row1Indexed !in 1..rows) return null
+        if (column1Indexed !in 1..columns) return null
+        return (row1Indexed - 1) * columns + (column1Indexed - 1)
     }
 
     fun rowIndices(row1Indexed: Int, rows: Int, columns: Int): SlotTarget.Indices? {


### PR DESCRIPTION
Previously only `slot(x)` we're being render now `slow(row, column)` is supported too.