### PR TITLE
IntelliJ plugin `availableSlot` preview support

### DIFF
--- a/intellij-plugin/TOOLING_SUPPORT.md
+++ b/intellij-plugin/TOOLING_SUPPORT.md
@@ -47,6 +47,16 @@ the user's code, so anything that depends on runtime state can only ever be appr
 - `availableSlot()` / `availableSlot(item)` / `availableSlot((index, builder) -> ...)`, placed by
   mirroring the runtime's own next-available-slot algorithm (`AvailableSlotInterceptor`) against
   what's already been statically extracted — see limitations below for what this can't account for.
+- Stack count: `new ItemStack(Material.X, amount)`'s second constructor argument, rendered as the
+  vanilla bottom-right count badge when it resolves to a literal or a local variable that's never
+  reassigned (so its initializer really is its value everywhere it's read), and is greater than `1`
+  (vanilla doesn't badge a single item, and a resolved `0`/negative amount is never shown either).
+  Inside an `availableSlot(...)` loop specifically (see `ForLoopAnalyzer`), an amount that's
+  literally the loop's own counter is resolved per iteration - `for (int i = 1; i <= 5; i++)
+  render.availableSlot(new ItemStack(Material.X, i))` badges `1` through `5` across the five slots
+  it actually claims, not one repeated number. Any other variable that genuinely differs per read -
+  a loop counter used some other way, or any other reassigned local - can't be reduced to a single
+  number, so it renders as `?` instead of a wrong frozen value.
 
 **Rendering**
 - `CHEST`-type views render on top of bundled sprite frames (`resources/assets/sprites/chest-1.png`

--- a/intellij-plugin/TOOLING_SUPPORT.md
+++ b/intellij-plugin/TOOLING_SUPPORT.md
@@ -44,6 +44,9 @@ the user's code, so anything that depends on runtime state can only ever be appr
   forms — see limitations below for the heuristic these rely on.
 - `renderWith(...)` / `onRender(...)` render as a distinct "dynamic" marker rather than being
   evaluated.
+- `availableSlot()` / `availableSlot(item)` / `availableSlot((index, builder) -> ...)`, placed by
+  mirroring the runtime's own next-available-slot algorithm (`AvailableSlotInterceptor`) against
+  what's already been statically extracted — see limitations below for what this can't account for.
 
 **Rendering**
 - `CHEST`-type views render on top of bundled sprite frames (`resources/assets/sprites/chest-1.png`
@@ -96,9 +99,19 @@ the user's code, so anything that depends on runtime state can only ever be appr
   loop) and what else has already filled slots. There's no loop-iteration analysis, so every call
   site is treated as if it fills the entire row/column. This matches the common idiom (see
   `RowColumnSample.java`) but is wrong for genuine single-slot usage.
-- **`availableSlot()` and `resultSlot()` are not placed.** Their position isn't statically knowable
-  (or, for `resultSlot()`, varies per `ViewType`), so items placed through them don't appear in the
-  preview at all.
+- **`availableSlot()` is placed with a heuristic, not a runtime-exact simulation.** Its real slot
+  is resolved procedurally at render time against the live container (which slots are interactable,
+  which already have an item) — the preview instead mirrors just the two algorithms
+  `AvailableSlotInterceptor` itself uses (sequential fill from slot 0, or fill of the layout's
+  reserved `'O'` positions when a `layout(...)` is set) against what's statically known: explicit
+  `slot`/`layoutSlot`/`row`/`column` bindings and the layout grid. It doesn't model per-slot
+  interactability for irregular container types. A call site directly inside a simple bounded
+  counting loop (`for (int i = a; i <op> b; i++`/`i--)`, variable on the left of the condition) is
+  counted once per statically-known iteration, since that's the idiomatic way to batch-fill
+  available slots; anything else - nested loops, for-each, while, a non-`i++`/`i--` step - falls
+  back to counting the call once, same as a bare call outside a loop.
+- **`resultSlot()` is not placed.** Its position varies per `ViewType` (a pagination-only concept)
+  and isn't modeled at all, so items placed through it don't appear in the preview.
 - **Extraction isn't scoped to a single view's methods.** The extractor walks the whole file's UAST
   tree for recognizable config/item calls rather than precisely following `onInit`/`onFirstRender`
   boundaries. In practice this only matters for files with multiple unrelated views or stray calls

--- a/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/ClickHandlerExtractor.kt
+++ b/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/ClickHandlerExtractor.kt
@@ -16,9 +16,16 @@ import org.jetbrains.uast.visitor.AbstractUastVisitor
 
 private const val FRAMEWORK_PACKAGE_PREFIX = "me.devnatan.inventoryframework"
 private const val ON_CLICK_METHOD = "onClick"
+private const val AVAILABLE_SLOT_METHOD = "availableSlot"
 private val ROW_COLUMN_FACTORY_METHODS = setOf("row", "firstRow", "lastRow", "column", "firstColumn", "lastColumn")
 
-class ClickActionExtractionResult(val indexed: Map<Int, PreviewClickAction>, val layoutBound: Map<Char, PreviewClickAction>)
+class ClickActionExtractionResult(
+    val indexed: Map<Int, PreviewClickAction>,
+    val layoutBound: Map<Char, PreviewClickAction>,
+    // Keyed by availableSlot(...) call site (SlotTarget.Available.anchor); ViewExtractor remaps
+    // these onto real slots once AvailableSlotResolver has run.
+    val availableSlotBound: Map<Int, PreviewClickAction>,
+)
 
 // Finds `.onClick(handler)` bindings, both the direct chain form ItemExtractor also resolves for
 // withItem (`slot(i).onClick(...)`, possibly with a `.withItem(...)` in between) and the row/column
@@ -36,11 +43,13 @@ object ClickHandlerExtractor {
     ): ClickActionExtractionResult {
         val indexed = mutableMapOf<Int, PreviewClickAction>()
         val layoutBound = mutableMapOf<Char, PreviewClickAction>()
+        val availableSlotBound = mutableMapOf<Int, PreviewClickAction>()
 
         fun apply(target: SlotTarget, action: PreviewClickAction) {
             when (target) {
                 is SlotTarget.Indices -> target.slots.forEach { indexed[it] = action }
                 is SlotTarget.Layout -> layoutBound[target.character] = action
+                is SlotTarget.Available -> availableSlotBound[target.anchor] = action
             }
         }
 
@@ -66,11 +75,22 @@ object ClickHandlerExtractor {
                     return false
                 }
 
+                // Only the BiConsumer factory-lambda shape of availableSlot(...) needs handling here
+                // (`.availableSlot((index, builder) -> builder.onClick(...))`); the 0/1-arg chained
+                // form (`.availableSlot().onClick(...)`) is already covered by the ON_CLICK_METHOD
+                // branch above, whose receiver-chain walk resolves back to it via SlotTargetResolver.
+                if (methodName == AVAILABLE_SLOT_METHOD) {
+                    resolveFactoryClickAction(node, rows, columns, stateIndex)?.let { (target, action) ->
+                        apply(target, action)
+                    }
+                    return false
+                }
+
                 return false
             }
         })
 
-        return ClickActionExtractionResult(indexed, layoutBound)
+        return ClickActionExtractionResult(indexed, layoutBound, availableSlotBound)
     }
 
     private fun resolveFactoryClickAction(

--- a/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/InventoryPreviewPanel.kt
+++ b/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/InventoryPreviewPanel.kt
@@ -10,6 +10,8 @@ import java.awt.Point
 import java.awt.RenderingHints
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
+import java.awt.geom.AffineTransform
+import java.awt.geom.Point2D
 import java.awt.image.BufferedImage
 import javax.imageio.ImageIO
 import javax.swing.JPanel
@@ -43,6 +45,10 @@ private const val HOPPER_SPRITE_ORIGIN_X = 43
 private const val HOPPER_SPRITE_ORIGIN_Y = 19
 private const val TITLE_FONT_SIZE = BASE_TITLE_FONT_SIZE * SPRITE_SCALE
 private const val SLOT_NUMBER_FONT_SIZE = BASE_SLOT_NUMBER_FONT_SIZE * SPRITE_SCALE - 2f
+// Vanilla's stack-count digits are small, tucked into an icon's corner - notably smaller than the
+// debug slot-number overlay above, which is deliberately oversized for dev-tool readability rather
+// than game fidelity.
+private const val STACK_COUNT_FONT_SIZE = 10f * SPRITE_SCALE
 
 // Vanilla Minecraft renders container titles in a fixed dark gray (0x404040) regardless of
 // any theme, since it's part of the emulated game screen rather than IDE chrome.
@@ -79,6 +85,7 @@ private val minecraftFont: Font? by lazy {
 
 private val titleFont: Font? by lazy { minecraftFont?.deriveFont(Font.PLAIN, TITLE_FONT_SIZE) }
 private val slotNumberFont: Font? by lazy { minecraftFont?.deriveFont(Font.PLAIN, SLOT_NUMBER_FONT_SIZE) }
+private val stackCountFont: Font? by lazy { minecraftFont?.deriveFont(Font.PLAIN, STACK_COUNT_FONT_SIZE) }
 
 class InventoryPreviewPanel : JPanel() {
 
@@ -161,14 +168,41 @@ class InventoryPreviewPanel : JPanel() {
         revalidate()
     }
 
+    private fun applyTextRenderingHints(g: Graphics2D) {
+        g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_OFF)
+        g.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON)
+    }
+
+    // Renders text at a pixel-accurate size and position regardless of the current zoom, leaving
+    // g.font/g.transform exactly as they were on return. Drawing text directly under the panel's
+    // g.scale(zoom, zoom) transform (zoom isn't always an integer: 0.5, 0.75, 1.25, 1.5, 3.0, ...)
+    // rasterizes a glyph hinted for the font's base size through that transform - with
+    // antialiasing off (kept off so the Minecraft font's blocky look stays crisp rather than
+    // turning blurry), the resulting on/off pixel rounding lands differently at each zoom level,
+    // which is what made the same glyph look bolder or thinner depending on zoom. Deriving the
+    // font at its real target size and drawing in screen space - rather than letting the
+    // transform scale up a rasterization done for a different size - keeps every zoom level
+    // equally crisp, the same way it already looked at zoom = 1.0.
+    private fun drawText(g: Graphics2D, text: String, logicalX: Int, logicalY: Int) {
+        val scale = g.transform.scaleX
+        val screenPoint = g.transform.transform(Point2D.Double(logicalX.toDouble(), logicalY.toDouble()), null)
+        val logicalTransform = g.transform
+        val logicalFont = g.font
+        g.transform = AffineTransform()
+        g.font = logicalFont.deriveFont((logicalFont.size2D * scale).toFloat())
+        g.drawString(text, screenPoint.x.toFloat(), screenPoint.y.toFloat())
+        g.transform = logicalTransform
+        g.font = logicalFont
+    }
+
     override fun paintComponent(g: Graphics) {
         super.paintComponent(g)
-        (g as Graphics2D).setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_OFF)
+        applyTextRenderingHints(g as Graphics2D)
         g.scale(zoom, zoom)
         val currentModel = model
         if (currentModel == null) {
             g.color = JBColor.foreground()
-            g.drawString("Unable to analyze this view", MIN_MARGIN, 20)
+            drawText(g, "Unable to analyze this view", MIN_MARGIN, 20)
             return
         }
 
@@ -184,7 +218,7 @@ class InventoryPreviewPanel : JPanel() {
 
     // Drawn after the grid/frame so the text sits on top of it, matching the in-game
     // layering where the title is part of the container's foreground, not a separate header.
-    private fun paintTitle(g: Graphics, model: PreviewModel, originX: Int, originY: Int) {
+    private fun paintTitle(g: Graphics2D, model: PreviewModel, originX: Int, originY: Int) {
         val title = model.title ?: "(dynamic title)"
         g.color = TITLE_COLOR
         val originalFont = g.font
@@ -194,7 +228,7 @@ class InventoryPreviewPanel : JPanel() {
         } else {
             (originX + TITLE_INSET_X) to (originY - TITLE_GRID_GAP - g.fontMetrics.descent)
         }
-        g.drawString(title, x, y)
+        drawText(g, title, x, y)
         g.font = originalFont
     }
 
@@ -279,8 +313,8 @@ class InventoryPreviewPanel : JPanel() {
         return index.takeIf { it < model.maxSize }
     }
 
-    private fun paintSpriteGrid(g: Graphics, model: PreviewModel, sprite: ContainerSprite, originX: Int, originY: Int) {
-        (g as Graphics2D).setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR)
+    private fun paintSpriteGrid(g: Graphics2D, model: PreviewModel, sprite: ContainerSprite, originX: Int, originY: Int) {
+        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR)
         g.drawImage(sprite.image, originX, originY, sprite.image.width * SPRITE_SCALE, sprite.image.height * SPRITE_SCALE, null)
 
         val (slotOriginX, slotOriginY, slotSize) = slotGeometry(model, originX, originY)
@@ -291,7 +325,7 @@ class InventoryPreviewPanel : JPanel() {
         }
     }
 
-    private fun paintDrawnGrid(g: Graphics, model: PreviewModel, originX: Int, originY: Int) {
+    private fun paintDrawnGrid(g: Graphics2D, model: PreviewModel, originX: Int, originY: Int) {
         val (slotOriginX, slotOriginY, slotSize) = slotGeometry(model, originX, originY)
         forEachSlot(model) { row, col ->
             val x = slotOriginX + col * slotSize
@@ -310,7 +344,7 @@ class InventoryPreviewPanel : JPanel() {
     }
 
     private fun paintSlotOverlay(
-        g: Graphics,
+        g: Graphics2D,
         model: PreviewModel,
         row: Int,
         col: Int,
@@ -348,16 +382,25 @@ class InventoryPreviewPanel : JPanel() {
         }
 
         if (icon != null) {
-            (g as Graphics2D).setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR)
+            g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR)
             val inset = size / 16
             g.drawImage(icon, x + inset, y + inset, size - inset * 2, size - inset * 2, null)
         }
 
         g.color = Color.BLACK
         when {
-            slot?.dynamic == true -> g.drawString("?", x + size / 2 - 3, y + size / 2 + 5)
-            slot?.material != null && icon == null -> g.drawString(abbreviateMaterial(slot.material), x + 3, y + size - 4)
+            slot?.dynamic == true -> drawText(g, "?", x + size / 2 - 3, y + size / 2 + 5)
+            slot?.material != null && icon == null -> drawText(g, abbreviateMaterial(slot.material), x + 3, y + size - 4)
         }
+
+        // Vanilla only badges a stack when it holds more than one item - a bare "1" (or an invalid
+        // 0/negative amount) is never shown - but a genuinely unresolvable amount (a reassigned/loop
+        // variable) still renders as "?" rather than looking identical to "no count at all".
+        val stackCountLabel = when {
+            slot?.amountDynamic == true -> "?"
+            else -> slot?.amount?.takeIf { it > 1 }?.toString()
+        }
+        stackCountLabel?.let { paintStackCount(g, it, x, y, size) }
 
         if (index in highlightedSlotIndices) {
             g.color = JBColor.BLUE
@@ -373,9 +416,25 @@ class InventoryPreviewPanel : JPanel() {
             g.color = SLOT_NUMBER_BACKGROUND
             g.fillRect(x + 1, y + 1, fm.stringWidth(label) + 4, fm.ascent + 3)
             g.color = Color.WHITE
-            g.drawString(label, x + 3, y + fm.ascent + 1)
+            drawText(g, label, x + 3, y + fm.ascent + 1)
             g.font = originalFont
         }
+    }
+
+    // Mirrors vanilla's stack-size badge: bottom-right corner, white text over a 1px black shadow
+    // rather than a background box (unlike the debug slot-number overlay above, which is IDE
+    // chrome, not part of the emulated game screen).
+    private fun paintStackCount(g: Graphics2D, label: String, x: Int, y: Int, size: Int) {
+        val originalFont = g.font
+        g.font = stackCountFont ?: g.font.deriveFont(STACK_COUNT_FONT_SIZE)
+        val fm = g.fontMetrics
+        val labelX = x + size - fm.stringWidth(label)
+        val labelY = y + size - 2
+        g.color = Color.BLACK
+        drawText(g, label, labelX + 2, labelY + 2)
+        g.color = Color.WHITE
+        drawText(g, label, labelX, labelY)
+        g.font = originalFont
     }
 
     private fun computePreferredSize(forModel: PreviewModel?): Dimension {
@@ -396,7 +455,7 @@ class InventoryPreviewPanel : JPanel() {
         val image = BufferedImage(size.width, size.height, BufferedImage.TYPE_INT_ARGB)
         val g = image.createGraphics()
         try {
-            g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_OFF)
+            applyTextRenderingHints(g)
             val (originX, originY) = exportOrigin(currentModel)
             val sprite = containerSpriteFor(currentModel)
             if (sprite != null) {

--- a/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/ItemExtractor.kt
+++ b/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/ItemExtractor.kt
@@ -2,20 +2,26 @@ package me.devnatan.inventoryframework.intellij
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiField
 import org.jetbrains.uast.UBinaryExpression
 import org.jetbrains.uast.UCallExpression
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UFile
+import org.jetbrains.uast.UForExpression
 import org.jetbrains.uast.UIfExpression
 import org.jetbrains.uast.ULambdaExpression
 import org.jetbrains.uast.ULiteralExpression
+import org.jetbrains.uast.UPostfixExpression
+import org.jetbrains.uast.UPrefixExpression
 import org.jetbrains.uast.UReferenceExpression
 import org.jetbrains.uast.UUnaryExpression
 import org.jetbrains.uast.UVariable
 import org.jetbrains.uast.UastBinaryOperator
 import org.jetbrains.uast.UastCallKind
+import org.jetbrains.uast.UastPostfixOperator
 import org.jetbrains.uast.UastPrefixOperator
+import org.jetbrains.uast.getParentOfType
 import org.jetbrains.uast.skipParenthesizedExprDown
 import org.jetbrains.uast.toUElementOfType
 import org.jetbrains.uast.visitor.AbstractUastVisitor
@@ -38,8 +44,11 @@ class ItemExtractionResult(
     val indexedConditionalItems: Map<Int, ConditionalItem>,
     val layoutConditionalItems: Map<Char, ConditionalItem>,
     // Keyed by availableSlot(...) call site (SlotTarget.Available.anchor), not a resolved slot -
-    // ViewExtractor remaps these onto real slots once AvailableSlotResolver has run.
-    val availableSlotBindings: Map<Int, PreviewSlot>,
+    // ViewExtractor remaps these onto real slots once AvailableSlotResolver has run. Usually a
+    // single-element list (the same binding repeated across every slot the anchor claims), but
+    // sized to the loop's iteration count - and varying per element - when resolveAvailableSlotItems
+    // recognizes the item's amount as literally the enclosing loop's own counter.
+    val availableSlotBindings: Map<Int, List<PreviewSlot>>,
     val availableSlotConditionalItems: Map<Int, ConditionalItem>,
 )
 
@@ -55,15 +64,19 @@ object ItemExtractor {
         val layoutBindings = mutableMapOf<Char, PreviewSlot>()
         val indexedConditionalItems = mutableMapOf<Int, ConditionalItem>()
         val layoutConditionalItems = mutableMapOf<Char, ConditionalItem>()
-        val availableSlotBindings = mutableMapOf<Int, PreviewSlot>()
+        val availableSlotBindings = mutableMapOf<Int, List<PreviewSlot>>()
         val availableSlotConditionalItems = mutableMapOf<Int, ConditionalItem>()
+        val reassignedVariables = collectReassignedVariables(uFile)
 
         fun apply(target: SlotTarget, slot: PreviewSlot?) {
             if (slot == null) return
             when (target) {
                 is SlotTarget.Indices -> target.slots.forEach { indexedSlots[it] = slot }
                 is SlotTarget.Layout -> layoutBindings[target.character] = slot
-                is SlotTarget.Available -> availableSlotBindings[target.anchor] = slot
+                // Reached only by the `.availableSlot().withItem(...)` chained form (via the
+                // ITEM_BINDING_METHODS branch below) - the direct/factory-lambda forms bypass apply()
+                // entirely for per-iteration amount support, see resolveAvailableSlotItems.
+                is SlotTarget.Available -> availableSlotBindings[target.anchor] = listOf(slot)
             }
         }
 
@@ -87,12 +100,12 @@ object ItemExtractor {
                     val receiverCall = asCallExpression(node.receiver) ?: return false
                     val target = SlotTargetResolver.resolve(receiverCall, rows, columns) ?: return false
                     if (methodName == "withItem") {
-                        val conditional = resolveConditionalItem(node.valueArguments[0], stateIndex, range)
+                        val conditional = resolveConditionalItem(node.valueArguments[0], stateIndex, range, reassignedVariables)
                         if (conditional != null) {
                             applyConditional(target, conditional)
                             apply(target, conditional.default)
                         } else {
-                            apply(target, resolveItem(node.valueArguments[0])?.copy(sourceRange = range))
+                            apply(target, resolveItem(node.valueArguments[0], reassignedVariables)?.copy(sourceRange = range))
                         }
                     } else {
                         apply(target, PreviewSlot(null, dynamic = true, sourceRange = range))
@@ -102,7 +115,7 @@ object ItemExtractor {
 
                 if (methodName in ROW_COLUMN_FACTORY_METHODS) {
                     resolveFactoryCall(node, rows, columns)?.let { (target, itemExpr) ->
-                        apply(target, resolveItem(itemExpr)?.copy(sourceRange = range))
+                        apply(target, resolveItem(itemExpr, reassignedVariables)?.copy(sourceRange = range))
                     }
                     return false
                 }
@@ -111,17 +124,21 @@ object ItemExtractor {
                 // a BiConsumer factory lambda (searched the same way as row/column factories) or a
                 // direct ItemStack (the Bukkit `availableSlot(item)` sugar, handled by
                 // resolveDirectItemCall like firstSlot(item)/lastSlot(item)) - so both are tried,
-                // whichever matches the actual argument shape.
+                // whichever matches the actual argument shape. Bypasses apply() (single-slot,
+                // single-binding) since a call site inside a loop needs one binding per iteration.
                 if (methodName == AVAILABLE_SLOT_METHOD) {
                     val result = resolveFactoryCall(node, rows, columns) ?: resolveDirectItemCall(node, rows, columns)
                     result?.let { (target, itemExpr) ->
-                        apply(target, resolveItem(itemExpr)?.copy(sourceRange = range))
+                        val anchor = (target as? SlotTarget.Available)?.anchor ?: return@let
+                        val items = resolveAvailableSlotItems(node, itemExpr, reassignedVariables)
+                            .map { it.copy(sourceRange = range) }
+                        if (items.isNotEmpty()) availableSlotBindings[anchor] = items
                     }
                     return false
                 }
 
                 resolveDirectItemCall(node, rows, columns)?.let { (target, itemExpr) ->
-                    apply(target, resolveItem(itemExpr)?.copy(sourceRange = range))
+                    apply(target, resolveItem(itemExpr, reassignedVariables)?.copy(sourceRange = range))
                 }
                 return false
             }
@@ -181,6 +198,37 @@ object ItemExtractor {
         }
     }
 
+    // availableSlot(...) inside a loop claims one slot per iteration (AvailableSlotResolver), and
+    // when the item's amount argument is literally that loop's own counter, its value genuinely
+    // differs per slot the same way the runtime's actual items would - e.g.
+    // `for (int i = 1; i <= 5; i++) render.availableSlot(new ItemStack(Material.X, i))` really
+    // does place a 1-stack, then a 2-stack, etc. In that specific recognized shape, one PreviewSlot
+    // per iteration is produced (varying only the amount); ViewExtractor then zips them
+    // positionally against the slots AvailableSlotResolver assigned to this call site's iterations.
+    // Anything else - amount isn't a reference at all, references a different variable, the call
+    // isn't directly inside a loop ForLoopAnalyzer can analyze - falls back to the single binding
+    // every other availableSlot(...) shape produces.
+    private fun resolveAvailableSlotItems(
+        availableSlotCall: UCallExpression,
+        itemExpr: UExpression,
+        reassignedVariables: Set<PsiElement>,
+    ): List<PreviewSlot> {
+        val baseline = resolveItem(itemExpr, reassignedVariables) ?: return emptyList()
+        val amountArg = amountArgumentOf(itemExpr) as? UReferenceExpression ?: return listOf(baseline)
+        val iteration = availableSlotCall.getParentOfType<UForExpression>(strict = true)
+            ?.let(ForLoopAnalyzer::analyze) ?: return listOf(baseline)
+        if (amountArg.resolve() != iteration.variable.sourcePsi) return listOf(baseline)
+        return iteration.values.map { baseline.copy(amount = it, amountDynamic = false) }
+    }
+
+    // The raw second constructor argument of an ItemStack(Material, amount[, damage]) call, if the
+    // item expression resolves to one - the same argument extractAmount() reads, but as the
+    // expression itself rather than an already-evaluated value, since resolveAvailableSlotItems
+    // needs its identity (is it literally the loop counter?), not just its value.
+    private fun amountArgumentOf(itemExpr: UExpression): UExpression? =
+        findItemStackConstructorCall(itemExpr.skipParenthesizedExprDown())
+            ?.valueArguments?.getOrNull(1)?.skipParenthesizedExprDown()
+
     // Detects `withItem(field.get(ctx) ? thenItem : elseItem)` / `withItem(!field.get(ctx) ? ... : ...)`
     // where `field` is a known boolean mutableState. Anything else (non-boolean state, a condition
     // that isn't a direct get() read, branches that aren't plain ItemStack constructors) isn't matched -
@@ -189,12 +237,13 @@ object ItemExtractor {
         rawExpr: UExpression?,
         stateIndex: Map<PsiField, PreviewStateDeclaration>,
         range: TextRange?,
+        reassignedVariables: Set<PsiElement>,
     ): ConditionalItem? {
         val expr = rawExpr?.skipParenthesizedExprDown() as? UIfExpression ?: return null
         if (!expr.isTernary) return null
         val match = resolveCondition(expr.condition, stateIndex) ?: return null
-        val thenSlot = resolveItem(expr.thenExpression)?.copy(sourceRange = range) ?: return null
-        val elseSlot = resolveItem(expr.elseExpression)?.copy(sourceRange = range) ?: return null
+        val thenSlot = resolveItem(expr.thenExpression, reassignedVariables)?.copy(sourceRange = range) ?: return null
+        val elseSlot = resolveItem(expr.elseExpression, reassignedVariables)?.copy(sourceRange = range) ?: return null
         val holds = match.condition.evaluate(match.declaration.initialValue) ?: return null
         val default = if (holds) thenSlot else elseSlot
         return ConditionalItem(match.condition, thenSlot, elseSlot, default)
@@ -257,13 +306,75 @@ object ItemExtractor {
         return field.takeIf { it in stateIndex }
     }
 
-    private fun resolveItem(rawExpr: UExpression?): PreviewSlot? {
+    private fun resolveItem(rawExpr: UExpression?, reassignedVariables: Set<PsiElement>): PreviewSlot? {
         if (rawExpr == null) return null
         val expr = rawExpr.skipParenthesizedExprDown()
         if (isNullLiteral(expr)) return null
-        val material = findItemStackConstructorCall(expr)?.let { extractMaterialName(it) }
-            ?: findMaterialArgument(expr)
-        return PreviewSlot(material = material, dynamic = material == null)
+        val constructorCall = findItemStackConstructorCall(expr)
+        val material = constructorCall?.let { extractMaterialName(it) } ?: findMaterialArgument(expr)
+        val amountArg = constructorCall?.valueArguments?.getOrNull(1)
+        val amount = amountArg?.let { resolveConstantInt(it, reassignedVariables) }
+        return PreviewSlot(
+            material = material,
+            dynamic = material == null,
+            amount = amount,
+            // A second constructor argument exists but couldn't be resolved to one value (a
+            // reassigned/loop variable, which really does hold something different on each read) -
+            // as opposed to no argument at all (ItemStack(Material) alone, implicitly 1).
+            amountDynamic = amountArg != null && amount == null,
+        )
+    }
+
+    // Reassignment makes a variable's declaration-site initializer meaningless as "the" value at
+    // any later read: a loop counter's initializer is only its starting value, not what it holds
+    // on a given iteration, so resolveConstantInt must never treat a reassigned variable as if its
+    // initializer were constant. Scans the whole file rather than just the variable's own scope
+    // since precision comes from resolving to the exact same PsiElement, not a narrower search
+    // radius - consistent with the extractor's existing whole-file, not per-method, analysis.
+    private fun collectReassignedVariables(uFile: UFile): Set<PsiElement> {
+        val reassigned = mutableSetOf<PsiElement>()
+        fun markIfReference(operand: UExpression) {
+            (operand.skipParenthesizedExprDown() as? UReferenceExpression)?.resolve()?.let { reassigned += it }
+        }
+        uFile.accept(object : AbstractUastVisitor() {
+            override fun visitBinaryExpression(node: UBinaryExpression): Boolean {
+                if (node.operator is UastBinaryOperator.AssignOperator) markIfReference(node.leftOperand)
+                return false
+            }
+
+            override fun visitPrefixExpression(node: UPrefixExpression): Boolean {
+                if (node.operator == UastPrefixOperator.INC || node.operator == UastPrefixOperator.DEC) {
+                    markIfReference(node.operand)
+                }
+                return false
+            }
+
+            override fun visitPostfixExpression(node: UPostfixExpression): Boolean {
+                if (node.operator == UastPostfixOperator.INC || node.operator == UastPostfixOperator.DEC) {
+                    markIfReference(node.operand)
+                }
+                return false
+            }
+        })
+        return reassigned
+    }
+
+    // ItemStack(Material) has no amount argument (implicit 1); ItemStack(Material, int amount) and
+    // the legacy ItemStack(Material, int amount, short damage) both carry it as the second
+    // constructor argument. evaluate() alone only folds literal expressions - it doesn't
+    // dereference a plain local variable reference to its initializer (same reason
+    // findItemStackConstructorCall/findMaterialArgument below do their own one-level variable
+    // indirection instead of relying on it) - so a variable is followed to its initializer here
+    // too, but only when it's never reassigned; a reassigned variable returns null (dynamic)
+    // rather than the misleading value it merely started at.
+    private fun resolveConstantInt(rawExpr: UExpression, reassignedVariables: Set<PsiElement>): Int? {
+        val expr = rawExpr.skipParenthesizedExprDown()
+        (expr.evaluate() as? Int)?.let { return it }
+        val ref = expr as? UReferenceExpression ?: return null
+        val variable = ref.resolve()?.toUElementOfType<UVariable>() ?: return null
+        if (variable.sourcePsi in reassignedVariables) return null
+        val initializer = variable.uastInitializer ?: return null
+        return resolveConstantInt(initializer, reassignedVariables)
     }
 
     private fun isNullLiteral(expr: UExpression): Boolean = (expr as? ULiteralExpression)?.isNull == true

--- a/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/ItemExtractor.kt
+++ b/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/ItemExtractor.kt
@@ -8,6 +8,7 @@ import org.jetbrains.uast.UCallExpression
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UFile
 import org.jetbrains.uast.UIfExpression
+import org.jetbrains.uast.ULambdaExpression
 import org.jetbrains.uast.ULiteralExpression
 import org.jetbrains.uast.UReferenceExpression
 import org.jetbrains.uast.UUnaryExpression
@@ -22,6 +23,7 @@ import org.jetbrains.uast.visitor.AbstractUastVisitor
 private const val ITEM_STACK_FQN = "org.bukkit.inventory.ItemStack"
 private const val MATERIAL_FQN = "org.bukkit.Material"
 private const val FRAMEWORK_PACKAGE_PREFIX = "me.devnatan.inventoryframework"
+private const val AVAILABLE_SLOT_METHOD = "availableSlot"
 private val ITEM_BINDING_METHODS = setOf("withItem", "renderWith", "onRender")
 private val ROW_COLUMN_FACTORY_METHODS = setOf("row", "firstRow", "lastRow", "column", "firstColumn", "lastColumn")
 // Java's `==`/`!=` map to IDENTITY_EQUALS/IDENTITY_NOT_EQUALS in UAST (not EQUALS/NOT_EQUALS,
@@ -35,6 +37,10 @@ class ItemExtractionResult(
     val layoutBindings: Map<Char, PreviewSlot>,
     val indexedConditionalItems: Map<Int, ConditionalItem>,
     val layoutConditionalItems: Map<Char, ConditionalItem>,
+    // Keyed by availableSlot(...) call site (SlotTarget.Available.anchor), not a resolved slot -
+    // ViewExtractor remaps these onto real slots once AvailableSlotResolver has run.
+    val availableSlotBindings: Map<Int, PreviewSlot>,
+    val availableSlotConditionalItems: Map<Int, ConditionalItem>,
 )
 
 object ItemExtractor {
@@ -49,12 +55,15 @@ object ItemExtractor {
         val layoutBindings = mutableMapOf<Char, PreviewSlot>()
         val indexedConditionalItems = mutableMapOf<Int, ConditionalItem>()
         val layoutConditionalItems = mutableMapOf<Char, ConditionalItem>()
+        val availableSlotBindings = mutableMapOf<Int, PreviewSlot>()
+        val availableSlotConditionalItems = mutableMapOf<Int, ConditionalItem>()
 
         fun apply(target: SlotTarget, slot: PreviewSlot?) {
             if (slot == null) return
             when (target) {
                 is SlotTarget.Indices -> target.slots.forEach { indexedSlots[it] = slot }
                 is SlotTarget.Layout -> layoutBindings[target.character] = slot
+                is SlotTarget.Available -> availableSlotBindings[target.anchor] = slot
             }
         }
 
@@ -62,6 +71,7 @@ object ItemExtractor {
             when (target) {
                 is SlotTarget.Indices -> target.slots.forEach { indexedConditionalItems[it] = item }
                 is SlotTarget.Layout -> layoutConditionalItems[target.character] = item
+                is SlotTarget.Available -> availableSlotConditionalItems[target.anchor] = item
             }
         }
 
@@ -97,6 +107,19 @@ object ItemExtractor {
                     return false
                 }
 
+                // availableSlot(...) has two single-arg shapes that only differ by argument type -
+                // a BiConsumer factory lambda (searched the same way as row/column factories) or a
+                // direct ItemStack (the Bukkit `availableSlot(item)` sugar, handled by
+                // resolveDirectItemCall like firstSlot(item)/lastSlot(item)) - so both are tried,
+                // whichever matches the actual argument shape.
+                if (methodName == AVAILABLE_SLOT_METHOD) {
+                    val result = resolveFactoryCall(node, rows, columns) ?: resolveDirectItemCall(node, rows, columns)
+                    result?.let { (target, itemExpr) ->
+                        apply(target, resolveItem(itemExpr)?.copy(sourceRange = range))
+                    }
+                    return false
+                }
+
                 resolveDirectItemCall(node, rows, columns)?.let { (target, itemExpr) ->
                     apply(target, resolveItem(itemExpr)?.copy(sourceRange = range))
                 }
@@ -104,7 +127,14 @@ object ItemExtractor {
             }
         })
 
-        return ItemExtractionResult(indexedSlots, layoutBindings, indexedConditionalItems, layoutConditionalItems)
+        return ItemExtractionResult(
+            indexedSlots,
+            layoutBindings,
+            indexedConditionalItems,
+            layoutConditionalItems,
+            availableSlotBindings,
+            availableSlotConditionalItems,
+        )
     }
 
     // row/column/firstRow/lastRow/firstColumn/lastColumn also have a `(BiConsumer<Integer, T> factory)`
@@ -140,6 +170,13 @@ object ItemExtractor {
                 val ch = args[0].evaluate() as? Char ?: return null
                 SlotTarget.Layout(ch) to args[1]
             } else null
+            // Only the direct-item shape (`availableSlot(item)`) belongs here; the factory-lambda
+            // shape is tried first by the caller and never reaches this branch.
+            "availableSlot" -> if (args.size == 1 && args[0].skipParenthesizedExprDown() !is ULambdaExpression) {
+                SlotTargetResolver.anchorOf(node)?.let { SlotTarget.Available(it) to args[0] }
+            } else {
+                null
+            }
             else -> null
         }
     }

--- a/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/MinecraftIconSettingsConfigurable.kt
+++ b/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/MinecraftIconSettingsConfigurable.kt
@@ -26,13 +26,11 @@ class MinecraftIconSettingsConfigurable : Configurable {
         homeField = field
 
         val comment = JLabel(
-            "<html>Used to render real item icons in the inventory preview by reading textures from an " +
-                "installed client jar. Leave empty to auto-detect the platform default " +
-                "(%APPDATA%/.minecraft, ~/.minecraft, or ~/Library/Application Support/minecraft).</html>",
+            "<html>Used to render real item icons in the inventory preview.<br/>Leave empty to auto-detect the platform default.</html>",
         )
 
         return FormBuilder.createFormBuilder()
-            .addLabeledComponent("Minecraft home (.minecraft) directory:", field)
+            .addLabeledComponent("Minecraft home:", field)
             .addComponentToRightColumn(comment)
             .addComponentFillVertically(JLabel(), 0)
             .panel

--- a/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/PreviewModel.kt
+++ b/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/PreviewModel.kt
@@ -2,7 +2,19 @@ package me.devnatan.inventoryframework.intellij
 
 import com.intellij.openapi.util.TextRange
 
-data class PreviewSlot(val material: String?, val dynamic: Boolean, val sourceRange: TextRange? = null)
+// amount is null either because there's no ItemStack(Material, int) constructor to read from (the
+// single-arg constructor, always 1) or its argument is a constant that just doesn't need a badge
+// (1, 0, negative - vanilla only badges a stack of 2+). amountDynamic distinguishes that from a
+// second constructor argument that genuinely couldn't be resolved to a single value (e.g. a
+// reassigned/loop variable, which really does differ per read) - that case still renders, as "?",
+// rather than silently looking identical to "no count at all".
+data class PreviewSlot(
+    val material: String?,
+    val dynamic: Boolean,
+    val amount: Int? = null,
+    val amountDynamic: Boolean = false,
+    val sourceRange: TextRange? = null,
+)
 
 enum class PreviewStateKind { BOOLEAN, INT }
 

--- a/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/SlotTargetResolver.kt
+++ b/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/SlotTargetResolver.kt
@@ -7,6 +7,13 @@ import org.jetbrains.uast.skipParenthesizedExprDown
 internal sealed class SlotTarget {
     data class Indices(val slots: List<Int>) : SlotTarget()
     data class Layout(val character: Char) : SlotTarget()
+
+    // availableSlot()'s real slot isn't known until every call site in the file has been
+    // collected (AvailableSlotResolver), so it's identified here by its call site's source offset
+    // rather than a resolved index - anchor lets bindings from the same call site (e.g. both
+    // withItem and onClick chained onto the same availableSlot()) converge on the same slot once
+    // resolved, without conflating it with a different availableSlot() call elsewhere in the file.
+    data class Available(val anchor: Int) : SlotTarget()
 }
 
 // Shared by ItemExtractor (withItem/renderWith/onRender) and ClickHandlerExtractor (onClick):
@@ -43,9 +50,18 @@ internal object SlotTargetResolver {
             "column" -> (args.getOrNull(0)?.evaluate() as? Int)?.let { columnIndices(it, rows, columns) }
             "firstColumn" -> columnIndices(1, rows, columns)
             "lastColumn" -> columnIndices(columns, rows, columns)
+            // Both the no-arg chained-builder form (`.availableSlot().withItem(...)`) and the
+            // direct-item sugar (`.availableSlot(item)`) are valid receivers here; the lambda-factory
+            // form (`.availableSlot((index, builder) -> ...)`) never appears as a receiver since it
+            // returns void, but is otherwise handled the same way via resolveFactoryLambda below.
+            "availableSlot" -> if (args.size <= 1) anchorOf(call)?.let { SlotTarget.Available(it) } else null
             else -> null
         }
     }
+
+    // Identifies an availableSlot(...) call site so bindings discovered from different receiver
+    // chains (or different extractor passes over the same UFile) can be matched back to it.
+    fun anchorOf(call: UCallExpression): Int? = call.sourcePsi?.textRange?.startOffset
 
     // Mirrors SlotConverter#convertSlot in the core module: 1-indexed row/column to a 0-indexed slot.
     fun slotIndex(row1Indexed: Int, column1Indexed: Int, rows: Int, columns: Int): Int? {
@@ -83,6 +99,11 @@ internal object SlotTargetResolver {
             } else null
             "firstColumn" -> if (args.size == 1) columnIndices(1, rows, columns)?.let { it to args[0] } else null
             "lastColumn" -> if (args.size == 1) columnIndices(columns, rows, columns)?.let { it to args[0] } else null
+            "availableSlot" -> if (args.size == 1) {
+                anchorOf(node)?.let { SlotTarget.Available(it) }?.let { it to args[0] }
+            } else {
+                null
+            }
             else -> null
         } ?: return null
 

--- a/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/ViewExtractor.kt
+++ b/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/ViewExtractor.kt
@@ -66,6 +66,13 @@ object ViewExtractor {
         val clickActions =
             clickActionResult.indexed + layoutBoundValues(layout, clickActionResult.layoutBound, columns)
 
+        // availableSlot(...)'s real slot(s) depend on every call site in the file (and, inside a
+        // countable loop, how many times it runs) plus everything already occupied by explicit
+        // bindings, so it can only be resolved once `slots` (the explicit ones) is known - see
+        // AvailableSlotResolver.
+        val availableAnchors = AvailableSlotResolver.collectAnchors(uFile)
+        val anchorToSlots = AvailableSlotResolver.resolve(availableAnchors, slots.keys, layout, columns, maxSize)
+
         return PreviewModel(
             viewTypeName = viewTypeFieldName ?: DEFAULT_VIEW_TYPE_NAME,
             rows = rows,
@@ -73,10 +80,10 @@ object ViewExtractor {
             maxSize = maxSize,
             title = title,
             layout = layout,
-            slots = slots,
+            slots = slots + remapByAnchor(items.availableSlotBindings, anchorToSlots),
             states = states.declarations,
-            conditionalItems = conditionalItems,
-            clickActions = clickActions,
+            conditionalItems = conditionalItems + remapByAnchor(items.availableSlotConditionalItems, anchorToSlots),
+            clickActions = clickActions + remapByAnchor(clickActionResult.availableSlotBound, anchorToSlots),
         )
     }
 
@@ -90,6 +97,18 @@ object ViewExtractor {
                 bindings[character]?.let { values[row * columns + col] = it }
             }
         }
+        return values
+    }
+
+    // Shared by items, conditional items and click actions bound through availableSlot(...) - all
+    // three are keyed by call-site anchor until AvailableSlotResolver assigns real slots, one call
+    // site's single statically-extracted binding fanning out to every slot it claimed (more than
+    // one when the call is inside a countable loop). A call site missing from anchorToSlots ran
+    // out of container capacity and is dropped rather than shown at a wrong or arbitrary position.
+    private fun <T> remapByAnchor(bindings: Map<Int, T>, anchorToSlots: Map<Int, List<Int>>): Map<Int, T> {
+        if (bindings.isEmpty()) return emptyMap()
+        val values = mutableMapOf<Int, T>()
+        bindings.forEach { (anchor, value) -> anchorToSlots[anchor]?.forEach { values[it] = value } }
         return values
     }
 

--- a/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/ViewExtractor.kt
+++ b/intellij-plugin/src/main/kotlin/me/devnatan/inventoryframework/intellij/ViewExtractor.kt
@@ -80,7 +80,7 @@ object ViewExtractor {
             maxSize = maxSize,
             title = title,
             layout = layout,
-            slots = slots + remapByAnchor(items.availableSlotBindings, anchorToSlots),
+            slots = slots + remapByAnchorSequence(items.availableSlotBindings, anchorToSlots),
             states = states.declarations,
             conditionalItems = conditionalItems + remapByAnchor(items.availableSlotConditionalItems, anchorToSlots),
             clickActions = clickActions + remapByAnchor(clickActionResult.availableSlotBound, anchorToSlots),
@@ -109,6 +109,21 @@ object ViewExtractor {
         if (bindings.isEmpty()) return emptyMap()
         val values = mutableMapOf<Int, T>()
         bindings.forEach { (anchor, value) -> anchorToSlots[anchor]?.forEach { values[it] = value } }
+        return values
+    }
+
+    // Like remapByAnchor, but for item bindings that can vary per iteration - a loop's induction
+    // variable read as an item's amount (see ItemExtractor.resolveAvailableSlotItems). Each
+    // resolved slot gets the binding at its own position in the call site's list; if there are more
+    // slots than bindings, the last binding repeats, which is exactly what a single-element list
+    // (every non-varying availableSlot(...) shape) does across all of its resolved slots.
+    private fun <T> remapByAnchorSequence(bindings: Map<Int, List<T>>, anchorToSlots: Map<Int, List<Int>>): Map<Int, T> {
+        if (bindings.isEmpty()) return emptyMap()
+        val values = mutableMapOf<Int, T>()
+        bindings.forEach { (anchor, perIteration) ->
+            if (perIteration.isEmpty()) return@forEach
+            anchorToSlots[anchor]?.forEachIndexed { i, slot -> values[slot] = perIteration.getOrElse(i) { perIteration.last() } }
+        }
         return values
     }
 


### PR DESCRIPTION
Adds support for `availableSlot` in the IntelliJ plugin previews.

<img width="1850" height="939" alt="image" src="https://github.com/user-attachments/assets/02428f3e-6df2-4644-9d42-cabb9e1bcd17" />
